### PR TITLE
docs: add team responsibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # team-continuous-frustration
 Repository for team Continuous Frustration
 
+## Team Responsibilities
+
+| Member | Main Responsibility |
+|---|---|
+| Paul Marius Heizmann | GenAI Component |
+| Khalil Hkiri | Server / Backend |
+| Siyao Zhou | Client / Frontend |
 
 ## Enable Pre-commit Hook
 


### PR DESCRIPTION
This PR adds a short team responsibility overview to the README.

Responsibilities:
- Paul Marius Heizmann: GenAI Component
- Khalil Hkiri: Server / Backend
- Siyao Zhou: Client / Frontend