### PR TITLE
chore: enable hot reload for containers in dev only

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,38 @@ From repository root, install and enable pre-commit:
 2. `pre-commit install`
 
 
-## Running Services
+## Starting All Services
+
+From the `infra/` directory, a single command starts everything (PostgreSQL, auth-service, flashcard-service, genai-service, web-client):
+
+```bash
+cd infra
+docker compose up --build
+```
+
+| Service | URL |
+|---|---|
+| Auth service | http://localhost:8083 |
+| Flashcard service | http://localhost:8082 |
+| GenAI service | http://localhost:8090 |
+| Web client | http://localhost:5173 |
+| PostgreSQL | localhost:5432 |
+
+The `.env` file in `infra/` already has defaults for local development. To stop all services:
+
+```bash
+docker compose down
+```
+
+To also remove the database volume (full reset):
+
+```bash
+docker compose down -v
+```
+
+---
+
+## Running Services Individually
 
 ### Flashcard Service
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     build:
       context: ..
       dockerfile: services/auth-service/Dockerfile
+      target: dev
     ports:
       - "${AUTH_SERVICE_PORT}:8081"
     environment:
@@ -28,6 +29,10 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRATION_MS: ${JWT_EXPIRATION_MS}
+    volumes:
+      - ../services/auth-service:/app/services/auth-service
+      - ../api:/app/api
+      - maven_cache:/root/.m2
     depends_on:
       db:
         condition: service_healthy
@@ -36,6 +41,7 @@ services:
     build:
       context: ..
       dockerfile: services/flashcard-service/Dockerfile
+      target: dev
     ports:
       - "${FLASHCARD_SERVICE_PORT}:8082"
     environment:
@@ -43,6 +49,10 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/flashcarddb
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ../services/flashcard-service:/app/services/flashcard-service
+      - ../api:/app/api
+      - maven_cache:/root/.m2
     depends_on:
       db:
         condition: service_healthy
@@ -62,9 +72,16 @@ services:
       - "5173:5173"
     environment:
       VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+      CHOKIDAR_USEPOLLING: "true"
+      WATCHPACK_POLLING: "true"
+    volumes:
+      - ../web-client:/app
+      - web_client_node_modules:/app/node_modules
     depends_on:
       - auth-service
       - flashcard-service
 
 volumes:
   postgres_data:
+  maven_cache:
+  web_client_node_modules:

--- a/services/auth-service/Dockerfile
+++ b/services/auth-service/Dockerfile
@@ -7,7 +7,12 @@ RUN mvn dependency:go-offline -q
 COPY services/auth-service/src src/
 RUN mvn package -DskipTests -q
 
-FROM eclipse-temurin:21-jre-alpine
+FROM maven:3.9-eclipse-temurin-21 AS dev
+WORKDIR /app/services/auth-service
+EXPOSE 8081
+CMD ["mvn", "spring-boot:run", "-q", "-Dspring-boot.run.fork=false"]
+
+FROM eclipse-temurin:21-jre-alpine AS prod
 WORKDIR /app
 COPY --from=build /app/services/auth-service/target/*.jar app.jar
 EXPOSE 8081

--- a/services/auth-service/pom.xml
+++ b/services/auth-service/pom.xml
@@ -45,6 +45,12 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/services/flashcard-service/Dockerfile
+++ b/services/flashcard-service/Dockerfile
@@ -7,7 +7,12 @@ RUN mvn dependency:go-offline -q
 COPY services/flashcard-service/src src/
 RUN mvn package -DskipTests -q
 
-FROM eclipse-temurin:21-jre-alpine
+FROM maven:3.9-eclipse-temurin-21 AS dev
+WORKDIR /app/services/flashcard-service
+EXPOSE 8082
+CMD ["mvn", "spring-boot:run", "-q", "-Dspring-boot.run.fork=false"]
+
+FROM eclipse-temurin:21-jre-alpine AS prod
 WORKDIR /app
 COPY --from=build /app/services/flashcard-service/target/*.jar app.jar
 EXPOSE 8082

--- a/services/flashcard-service/pom.xml
+++ b/services/flashcard-service/pom.xml
@@ -37,6 +37,12 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>

--- a/web-client/Dockerfile
+++ b/web-client/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20
 
 WORKDIR /app
 
-COPY . .
+COPY package.json package-lock.json* ./
 
 RUN npm install
 


### PR DESCRIPTION
Add a `dev` build target to the Spring service Dockerfiles that runs `mvn spring-boot:run` against bind-mounted source, and add spring-boot-devtools so classpath changes trigger a fast restart. Bind-mount source + a maven cache volume in docker-compose so edits on the host are picked up without rebuilding. For the web client, drop the source COPY (the bind mount supplies it), keep `npm run dev` for Vite HMR, and enable polling for macOS file watching.