### PR TITLE
fix(web): replace Vite dev server with nginx production build

### DIFF
--- a/infra/docker-compose.azure.yml
+++ b/infra/docker-compose.azure.yml
@@ -94,9 +94,7 @@ services:
   web-client:
     image: ghcr.io/aet-devops26/team-continuous-frustration/web-client:latest
     expose:
-      - "5173"
-    environment:
-      VITE_API_BASE_URL: ''
+      - "80"
     depends_on:
       - auth-service
       - flashcard-service
@@ -104,7 +102,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.client.rule=Host(`${CLIENT_HOST}`)"
-      - "traefik.http.services.client.loadbalancer.server.port=5173"
+      - "traefik.http.services.client.loadbalancer.server.port=80"
       - "traefik.http.routers.client.entrypoints=websecure"
       - "traefik.http.routers.client.tls.certresolver=letsencrypt"
       - "traefik.http.middlewares.client-compress.compress=true"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -68,6 +68,7 @@ services:
   web-client:
     build:
       context: ../web-client
+      target: dev
     ports:
       - "5273:5173"
     environment:

--- a/web-client/Dockerfile
+++ b/web-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.18.0-slim
+FROM node:22.18.0-slim AS dev
 
 WORKDIR /app
 
@@ -8,5 +8,23 @@ RUN npm ci
 COPY . .
 
 EXPOSE 5173
-
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+
+# ---
+
+FROM node:22.18.0-slim AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine AS production
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/web-client/nginx.conf
+++ b/web-client/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(?:js|css|woff2?|png|jpg|webp|svg|ico)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+}

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -14,9 +14,4 @@ export default defineConfig({
     host: '0.0.0.0',
     allowedHosts: true,
   },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
 })


### PR DESCRIPTION
The dev server relies on WebSocket/HMR to inject Tailwind CSS at runtime. Behind Traefik this connection never establishes, so the page renders with no styles. Fix by adding a multi-stage Dockerfile: a `dev` target keeps hot reload for local work, and the default `production` target runs vite build and serves the static output via nginx. Update both compose files accordingly.