### PR TITLE
fix(ci): align SCP target with SSH working directory in deploy workflow

### DIFF
--- a/.github/workflows/deploy_azure.yaml
+++ b/.github/workflows/deploy_azure.yaml
@@ -20,7 +20,7 @@ jobs:
           username: ${{ vars.AZURE_USER }}
           key: ${{ secrets.AZURE_PRIVATE_KEY }}
           source: "./infra/docker-compose.azure.yml"
-          target: /home/${{ vars.AZURE_USER }}
+          target: /home/${{ vars.AZURE_USER }}/team-continuous-frustration
 
       - name: SSH to VM and Create .env.prod
         uses: appleboy/ssh-action@v1.0.3

--- a/infra/docker-compose.azure.yml
+++ b/infra/docker-compose.azure.yml
@@ -37,7 +37,7 @@ services:
       retries: 5
 
   auth-service:
-    image: ghcr.io/aet-devops26/team-continuous-frustration/auth-service:$latest
+    image: ghcr.io/aet-devops26/team-continuous-frustration/auth-service:latest
     expose:
       - "8081"
     environment:


### PR DESCRIPTION
The SCP step was copying docker-compose.azure.yml to /home/azureuser/infra/ while the SSH step ran docker compose from /home/azureuser/team-continuous-frustration/infra/. This caused the old locally-built compose file (with dev server on port 5173) to be used instead of the updated one with the nginx production image on port 80.