### PR TITLE
feat(auth): add session management, email/password login, and protect…

### DIFF
--- a/api/auth.yaml
+++ b/api/auth.yaml
@@ -46,6 +46,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/v1/auth/me:
+    get:
+      summary: Get the currently authenticated user
+      operationId: getMe
+      tags:
+        - Auth
+      security: []
+      responses:
+        '200':
+          description: Authenticated user info
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeResponse'
+        '401':
+          description: No valid session
+
+  /api/v1/auth/logout:
+    post:
+      summary: Revoke the current session
+      operationId: logout
+      tags:
+        - Auth
+      security: []
+      responses:
+        '204':
+          description: Session revoked and cookie cleared
+
 components:
   schemas:
     RegisterRequest:
@@ -69,6 +97,21 @@ components:
           example: john_doe
 
     RegisterResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 123e4567-e89b-12d3-a456-426614174000
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        username:
+          type: string
+          example: john_doe
+
+    MeResponse:
       type: object
       properties:
         id:

--- a/services/auth-service/src/main/java/com/devops/authservice/config/OAuth2SuccessHandler.java
+++ b/services/auth-service/src/main/java/com/devops/authservice/config/OAuth2SuccessHandler.java
@@ -1,31 +1,36 @@
 package com.devops.authservice.config;
 
+import com.devops.authservice.entity.SessionEntity;
 import com.devops.authservice.entity.UserEntity;
 import com.devops.authservice.repository.UserRepository;
-import com.devops.authservice.service.JwtService;
+import com.devops.authservice.service.SessionService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 @Component
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final UserRepository userRepository;
-    private final JwtService jwtService;
+    private final SessionService sessionService;
     private final String frontendUrl;
 
     public OAuth2SuccessHandler(
             UserRepository userRepository,
-            JwtService jwtService,
+            SessionService sessionService,
             @Value("${frontend.url}") String frontendUrl) {
         this.userRepository = userRepository;
-        this.jwtService = jwtService;
+        this.sessionService = sessionService;
         this.frontendUrl = frontendUrl;
     }
 
@@ -38,8 +43,17 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         UserEntity user = userRepository.findByGoogleId(googleId)
                 .orElseThrow(() -> new IllegalStateException("User not found after OAuth2 login"));
 
-        String token = jwtService.generate(user.getId(), user.getEmail());
+        SessionEntity session = sessionService.create(user.getId());
 
-        response.sendRedirect(frontendUrl + "/oauth-callback?token=" + token);
+        Duration maxAge = Duration.between(LocalDateTime.now(), session.getExpiresAt());
+        ResponseCookie cookie = ResponseCookie.from("session_id", session.getId().toString())
+                .httpOnly(true)
+                .path("/")
+                .maxAge(maxAge)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        response.sendRedirect(frontendUrl + "/oauth-callback");
     }
 }

--- a/services/auth-service/src/main/java/com/devops/authservice/controller/session/SessionController.java
+++ b/services/auth-service/src/main/java/com/devops/authservice/controller/session/SessionController.java
@@ -1,0 +1,75 @@
+package com.devops.authservice.controller.session;
+
+import com.devops.authservice.entity.SessionEntity;
+import com.devops.authservice.entity.UserEntity;
+import com.devops.authservice.repository.UserRepository;
+import com.devops.authservice.service.SessionService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class SessionController {
+
+    private final SessionService sessionService;
+    private final UserRepository userRepository;
+
+    public SessionController(SessionService sessionService, UserRepository userRepository) {
+        this.sessionService = sessionService;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<Map<String, Object>> me(HttpServletRequest request) {
+        return extractSessionId(request)
+                .flatMap(sessionService::validate)
+                .flatMap(session -> userRepository.findById(session.getUserId()))
+                .map(user -> ResponseEntity.ok(toMap(user)))
+                .orElseGet(() -> ResponseEntity.status(401).build());
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        extractSessionId(request).ifPresent(sessionService::revoke);
+
+        ResponseCookie clear = ResponseCookie.from("session_id", "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, clear.toString());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    private Optional<UUID> extractSessionId(HttpServletRequest request) {
+        if (request.getCookies() == null) return Optional.empty();
+        return Arrays.stream(request.getCookies())
+                .filter(c -> "session_id".equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .map(value -> {
+                    try { return UUID.fromString(value); } catch (IllegalArgumentException e) { return null; }
+                })
+                .filter(id -> id != null);
+    }
+
+    private Map<String, Object> toMap(UserEntity user) {
+        return Map.of(
+                "id", user.getId().toString(),
+                "email", user.getEmail(),
+                "username", user.getUsername()
+        );
+    }
+}

--- a/services/auth-service/src/main/java/com/devops/authservice/controller/user/login/LoginController.java
+++ b/services/auth-service/src/main/java/com/devops/authservice/controller/user/login/LoginController.java
@@ -1,0 +1,65 @@
+package com.devops.authservice.controller.user.login;
+
+import com.devops.authservice.entity.SessionEntity;
+import com.devops.authservice.entity.UserEntity;
+import com.devops.authservice.repository.UserRepository;
+import com.devops.authservice.service.SessionService;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class LoginController {
+
+    private final UserRepository userRepository;
+    private final SessionService sessionService;
+    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    public LoginController(UserRepository userRepository, SessionService sessionService) {
+        this.userRepository = userRepository;
+        this.sessionService = sessionService;
+    }
+
+    record LoginRequest(String email, String password) {}
+
+    @PostMapping("/login")
+    public ResponseEntity<Map<String, Object>> login(
+            @RequestBody LoginRequest request,
+            HttpServletResponse response) {
+
+        UserEntity user = userRepository.findByEmail(request.email()).orElse(null);
+
+        if (user == null || user.getPasswordHash() == null
+                || !passwordEncoder.matches(request.password(), user.getPasswordHash())) {
+            return ResponseEntity.status(401)
+                    .body(Map.of("code", "INVALID_CREDENTIALS", "message", "Invalid email or password."));
+        }
+
+        SessionEntity session = sessionService.create(user.getId());
+        Duration maxAge = Duration.between(LocalDateTime.now(), session.getExpiresAt());
+        ResponseCookie cookie = ResponseCookie.from("session_id", session.getId().toString())
+                .httpOnly(true)
+                .path("/")
+                .maxAge(maxAge)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ResponseEntity.ok(Map.of(
+                "id", user.getId().toString(),
+                "email", user.getEmail(),
+                "username", user.getUsername()
+        ));
+    }
+}

--- a/services/auth-service/src/main/java/com/devops/authservice/controller/user/register/RegisterController.java
+++ b/services/auth-service/src/main/java/com/devops/authservice/controller/user/register/RegisterController.java
@@ -1,28 +1,54 @@
 package com.devops.authservice.controller.user.register;
 
-import com.devops.authservice.api.AuthApi;
 import com.devops.authservice.domain.user.register.RegisterInput;
 import com.devops.authservice.domain.user.register.RegisterInteractor;
 import com.devops.authservice.domain.user.register.RegisterOutput;
+import com.devops.authservice.entity.SessionEntity;
 import com.devops.authservice.model.RegisterRequest;
 import com.devops.authservice.model.RegisterResponse;
+import com.devops.authservice.service.SessionService;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+
 @RestController
-public class RegisterController implements AuthApi {
+@RequestMapping("/api/v1/auth")
+public class RegisterController {
 
     private final RegisterInteractor interactor;
+    private final SessionService sessionService;
 
-    public RegisterController(RegisterInteractor interactor) {
+    public RegisterController(RegisterInteractor interactor, SessionService sessionService) {
         this.interactor = interactor;
+        this.sessionService = sessionService;
     }
 
-    @Override
-    public ResponseEntity<RegisterResponse> registerUser(RegisterRequest request) {
-        RegisterInput input = decode(request);
-        RegisterOutput output = interactor.execute(input);
+    @PostMapping("/register")
+    public ResponseEntity<RegisterResponse> registerUser(
+            @Valid @RequestBody RegisterRequest request,
+            HttpServletResponse response) {
+        RegisterOutput output = interactor.execute(decode(request));
+
+        SessionEntity session = sessionService.create(output.id());
+        Duration maxAge = Duration.between(LocalDateTime.now(), session.getExpiresAt());
+        ResponseCookie cookie = ResponseCookie.from("session_id", session.getId().toString())
+                .httpOnly(true)
+                .path("/")
+                .maxAge(maxAge)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
         return ResponseEntity.status(HttpStatus.CREATED).body(encode(output));
     }
 

--- a/services/auth-service/src/main/java/com/devops/authservice/entity/SessionEntity.java
+++ b/services/auth-service/src/main/java/com/devops/authservice/entity/SessionEntity.java
@@ -1,0 +1,48 @@
+package com.devops.authservice.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "sessions")
+public class SessionEntity {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SessionStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private LocalDateTime lastUsedAt;
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+
+    public UUID getUserId() { return userId; }
+    public void setUserId(UUID userId) { this.userId = userId; }
+
+    public SessionStatus getStatus() { return status; }
+    public void setStatus(SessionStatus status) { this.status = status; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public LocalDateTime getExpiresAt() { return expiresAt; }
+    public void setExpiresAt(LocalDateTime expiresAt) { this.expiresAt = expiresAt; }
+
+    public LocalDateTime getLastUsedAt() { return lastUsedAt; }
+    public void setLastUsedAt(LocalDateTime lastUsedAt) { this.lastUsedAt = lastUsedAt; }
+}

--- a/services/auth-service/src/main/java/com/devops/authservice/entity/SessionStatus.java
+++ b/services/auth-service/src/main/java/com/devops/authservice/entity/SessionStatus.java
@@ -1,0 +1,5 @@
+package com.devops.authservice.entity;
+
+public enum SessionStatus {
+    ACTIVE, REVOKED, EXPIRED
+}

--- a/services/auth-service/src/main/java/com/devops/authservice/repository/SessionRepository.java
+++ b/services/auth-service/src/main/java/com/devops/authservice/repository/SessionRepository.java
@@ -1,0 +1,13 @@
+package com.devops.authservice.repository;
+
+import com.devops.authservice.entity.SessionEntity;
+import com.devops.authservice.entity.SessionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SessionRepository extends JpaRepository<SessionEntity, UUID> {
+
+    Optional<SessionEntity> findByIdAndStatus(UUID id, SessionStatus status);
+}

--- a/services/auth-service/src/main/java/com/devops/authservice/service/SessionService.java
+++ b/services/auth-service/src/main/java/com/devops/authservice/service/SessionService.java
@@ -1,0 +1,54 @@
+package com.devops.authservice.service;
+
+import com.devops.authservice.entity.SessionEntity;
+import com.devops.authservice.entity.SessionStatus;
+import com.devops.authservice.repository.SessionRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class SessionService {
+
+    private final SessionRepository sessionRepository;
+    private final long expirationMs;
+
+    public SessionService(
+            SessionRepository sessionRepository,
+            @Value("${session.expiration-ms:86400000}") long expirationMs) {
+        this.sessionRepository = sessionRepository;
+        this.expirationMs = expirationMs;
+    }
+
+    public SessionEntity create(UUID userId) {
+        LocalDateTime now = LocalDateTime.now();
+        SessionEntity session = new SessionEntity();
+        session.setId(UUID.randomUUID());
+        session.setUserId(userId);
+        session.setStatus(SessionStatus.ACTIVE);
+        session.setCreatedAt(now);
+        session.setLastUsedAt(now);
+        session.setExpiresAt(now.plus(expirationMs, ChronoUnit.MILLIS));
+        return sessionRepository.save(session);
+    }
+
+    public Optional<SessionEntity> validate(UUID sessionId) {
+        return sessionRepository.findByIdAndStatus(sessionId, SessionStatus.ACTIVE)
+                .filter(s -> s.getExpiresAt().isAfter(LocalDateTime.now()))
+                .map(s -> {
+                    s.setLastUsedAt(LocalDateTime.now());
+                    return sessionRepository.save(s);
+                });
+    }
+
+    public void revoke(UUID sessionId) {
+        sessionRepository.findById(sessionId).ifPresent(s -> {
+            s.setStatus(SessionStatus.REVOKED);
+            sessionRepository.save(s);
+        });
+    }
+}

--- a/services/auth-service/src/main/resources/application.properties
+++ b/services/auth-service/src/main/resources/application.properties
@@ -20,3 +20,5 @@ spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_
 spring.security.oauth2.client.registration.google.scope=email,profile
 
 frontend.url=${FRONTEND_URL:http://localhost:5273}
+
+session.expiration-ms=${SESSION_EXPIRATION_MS:86400000}

--- a/services/auth-service/src/main/resources/db/changelog/changes/003_create_sessions.yaml
+++ b/services/auth-service/src/main/resources/db/changelog/changes/003_create_sessions.yaml
@@ -1,0 +1,59 @@
+databaseChangeLog:
+  - changeSet:
+      id: 003_create_sessions
+      author: team-continuous-frustration
+      changes:
+        - createTable:
+            tableName: sessions
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: varchar(20)
+                  defaultValue: ACTIVE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_at
+                  type: timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_used_at
+                  type: timestamp
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: sessions
+            baseColumnNames: user_id
+            referencedTableName: users
+            referencedColumnNames: id
+            constraintName: fk_sessions_user_id
+            onDelete: CASCADE
+        - createIndex:
+            tableName: sessions
+            indexName: idx_sessions_user_id
+            columns:
+              - column:
+                  name: user_id
+        - createIndex:
+            tableName: sessions
+            indexName: idx_sessions_expires_at
+            columns:
+              - column:
+                  name: expires_at

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -1,5 +1,7 @@
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
+import { AuthProvider } from "./context/AuthContext";
+import { ProtectedRoute } from "./components/ProtectedRoute";
 import { AppLayout } from "./components/AppLayout";
 import { HomePage } from "./pages/HomePage";
 import { LoginPage } from "./pages/LoginPage";
@@ -14,26 +16,25 @@ import { OAuthCallbackPage } from "./pages/OAuthCallbackPage";
 function App() {
     return (
         <BrowserRouter>
-            <Routes>
-                <Route element={<AppLayout />}>
-                    <Route path="/" element={<HomePage />} />
+            <AuthProvider>
+                <Routes>
+                    <Route element={<AppLayout />}>
+                        <Route path="/login" element={<LoginPage />} />
+                        <Route path="/register" element={<RegisterPage />} />
+                        <Route path="/oauth-callback" element={<OAuthCallbackPage />} />
 
-                    <Route path="/login" element={<LoginPage />} />
-                    <Route path="/register" element={<RegisterPage />} />
+                        <Route path="/" element={<ProtectedRoute><HomePage /></ProtectedRoute>} />
+                        <Route path="/upload" element={<ProtectedRoute><UploadPage /></ProtectedRoute>} />
+                        <Route path="/cards" element={<ProtectedRoute><CardStudioPage /></ProtectedRoute>} />
+                        <Route path="/decks" element={<ProtectedRoute><DecksPage /></ProtectedRoute>} />
+                        <Route path="/decks/:deckId" element={<ProtectedRoute><DeckDetailPage /></ProtectedRoute>} />
+                        <Route path="/study" element={<ProtectedRoute><StudySessionPage /></ProtectedRoute>} />
+                        <Route path="/study/:deckId" element={<ProtectedRoute><StudySessionPage /></ProtectedRoute>} />
 
-                    <Route path="/upload" element={<UploadPage />} />
-                    <Route path="/cards" element={<CardStudioPage />} />
-
-                    <Route path="/decks" element={<DecksPage />} />
-                    <Route path="/decks/:deckId" element={<DeckDetailPage />} />
-
-                    <Route path="/study" element={<StudySessionPage />} />
-                    <Route path="/study/:deckId" element={<StudySessionPage />} />
-
-                    <Route path="/oauth-callback" element={<OAuthCallbackPage />} />
-                    <Route path="*" element={<Navigate to="/" replace />} />
-                </Route>
-            </Routes>
+                        <Route path="*" element={<Navigate to="/" replace />} />
+                    </Route>
+                </Routes>
+            </AuthProvider>
         </BrowserRouter>
     );
 }

--- a/web-client/src/components/AppHeader.tsx
+++ b/web-client/src/components/AppHeader.tsx
@@ -2,8 +2,11 @@ import { Link } from "react-router-dom";
 import { Sprout } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { useAuth } from "@/context/AuthContext";
 
 export function AppHeader() {
+  const { isAuthenticated, isLoading, user, logout } = useAuth();
+
   return (
     <header className="sticky top-0 z-30 border-b border-border/60 bg-background/80 backdrop-blur-md">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
@@ -15,14 +18,27 @@ export function AppHeader() {
             Kindling
           </span>
         </Link>
-        <nav className="flex items-center gap-2">
-          <Button asChild variant="ghost" size="sm">
-            <Link to="/login">Sign in</Link>
-          </Button>
-          <Button asChild size="sm">
-            <Link to="/register">Get started</Link>
-          </Button>
-        </nav>
+        {!isLoading && (
+          <nav className="flex items-center gap-2">
+            {isAuthenticated ? (
+              <>
+                <span className="text-sm text-muted-foreground">{user?.username}</span>
+                <Button variant="ghost" size="sm" onClick={logout}>
+                  Sign out
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button asChild variant="ghost" size="sm">
+                  <Link to="/login">Sign in</Link>
+                </Button>
+                <Button asChild size="sm">
+                  <Link to="/register">Get started</Link>
+                </Button>
+              </>
+            )}
+          </nav>
+        )}
       </div>
     </header>
   );

--- a/web-client/src/components/ProtectedRoute.tsx
+++ b/web-client/src/components/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "@/context/AuthContext";
+
+export function ProtectedRoute({ children }: { children: ReactNode }) {
+    const { isAuthenticated, isLoading } = useAuth();
+
+    if (isLoading) return null;
+    if (!isAuthenticated) return <Navigate to="/login" replace />;
+
+    return <>{children}</>;
+}

--- a/web-client/src/context/AuthContext.tsx
+++ b/web-client/src/context/AuthContext.tsx
@@ -1,0 +1,57 @@
+import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from "react";
+
+interface User {
+    id: string;
+    email: string;
+    username: string;
+}
+
+interface AuthContextType {
+    user: User | null;
+    isLoading: boolean;
+    isAuthenticated: boolean;
+    updateUser: (user: User) => void;
+    refetch: () => Promise<void>;
+    logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+const API = import.meta.env.VITE_API_BASE_URL ?? "";
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+    const [user, setUser] = useState<User | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+
+    const refetch = useCallback(async () => {
+        try {
+            const res = await fetch(`${API}/api/v1/auth/me`, { credentials: "include" });
+            setUser(res.ok ? await res.json() : null);
+        } catch {
+            setUser(null);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => { refetch(); }, [refetch]);
+
+    const logout = async () => {
+        await fetch(`${API}/api/v1/auth/logout`, { method: "POST", credentials: "include" });
+        setUser(null);
+    };
+
+    const updateUser = (u: User) => setUser(u);
+
+    return (
+        <AuthContext.Provider value={{ user, isLoading, isAuthenticated: user !== null, updateUser, refetch, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+}
+
+export function useAuth(): AuthContextType {
+    const ctx = useContext(AuthContext);
+    if (!ctx) throw new Error("useAuth must be used inside AuthProvider");
+    return ctx;
+}

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -6,6 +6,7 @@ import App from './App.tsx'
 
 const baseUrl = import.meta.env.VITE_API_BASE_URL ?? ''
 axios.defaults.baseURL = baseUrl
+axios.defaults.withCredentials = true
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/web-client/src/pages/LoginPage.tsx
+++ b/web-client/src/pages/LoginPage.tsx
@@ -1,19 +1,47 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Sprout } from "lucide-react";
+import axios from "axios";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useAuth } from "@/context/AuthContext";
 
 export function LoginPage() {
   const navigate = useNavigate();
+  const { updateUser } = useAuth();
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
 
   const google = () => {
     window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/google`;
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError("");
+    setBusy(true);
+    try {
+      const res = await axios.post<{ id: string; email: string; username: string }>(
+        "/api/v1/auth/login",
+        { email, password }
+      );
+      updateUser(res.data);
+      navigate("/", { replace: true });
+    } catch (err: any) {
+      const code = err?.response?.data?.code;
+      if (code === "INVALID_CREDENTIALS") {
+        setError("Invalid email or password.");
+      } else {
+        setError("Something went wrong. Please try again.");
+      }
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (
@@ -44,22 +72,10 @@ export function LoginPage() {
           disabled={busy}
         >
           <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-            <path
-              fill="#4285F4"
-              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.76h3.56c2.08-1.92 3.28-4.74 3.28-8.09z"
-            />
-            <path
-              fill="#34A853"
-              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.56-2.76c-.99.66-2.25 1.06-3.72 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0 0 12 23z"
-            />
-            <path
-              fill="#FBBC05"
-              d="M5.84 14.11A6.6 6.6 0 0 1 5.5 12c0-.73.13-1.44.34-2.11V7.05H2.18A11 11 0 0 0 1 12c0 1.78.43 3.46 1.18 4.95l3.66-2.84z"
-            />
-            <path
-              fill="#EA4335"
-              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1A11 11 0 0 0 2.18 7.05l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z"
-            />
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.76h3.56c2.08-1.92 3.28-4.74 3.28-8.09z" />
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.56-2.76c-.99.66-2.25 1.06-3.72 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0 0 12 23z" />
+            <path fill="#FBBC05" d="M5.84 14.11A6.6 6.6 0 0 1 5.5 12c0-.73.13-1.44.34-2.11V7.05H2.18A11 11 0 0 0 1 12c0 1.78.43 3.46 1.18 4.95l3.66-2.84z" />
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1A11 11 0 0 0 2.18 7.05l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z" />
           </svg>
           Continue with Google
         </Button>
@@ -69,14 +85,7 @@ export function LoginPage() {
           <span className="h-px flex-1 bg-border" />
         </div>
 
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-            setBusy(true);
-            navigate("/");
-          }}
-          className="space-y-3"
-        >
+        <form onSubmit={handleSubmit} className="space-y-3">
           <div className="space-y-1.5">
             <Label htmlFor="email">Email</Label>
             <Input
@@ -84,7 +93,7 @@ export function LoginPage() {
               type="email"
               required
               value={email}
-              onChange={(event) => setEmail(event.target.value)}
+              onChange={(e) => setEmail(e.target.value)}
             />
           </div>
           <div className="space-y-1.5">
@@ -93,11 +102,11 @@ export function LoginPage() {
               id="password"
               type="password"
               required
-              minLength={6}
               value={password}
-              onChange={(event) => setPassword(event.target.value)}
+              onChange={(e) => setPassword(e.target.value)}
             />
           </div>
+          {error && <p className="text-xs text-destructive">{error}</p>}
           <Button type="submit" className="w-full" disabled={busy}>
             {busy ? "Please wait…" : "Sign in"}
           </Button>
@@ -105,10 +114,7 @@ export function LoginPage() {
 
         <p className="mt-5 text-center text-sm text-muted-foreground">
           No account?{" "}
-          <Link
-            to="/register"
-            className="font-medium text-primary hover:underline"
-          >
+          <Link to="/register" className="font-medium text-primary hover:underline">
             Sign up
           </Link>
         </p>

--- a/web-client/src/pages/OAuthCallbackPage.tsx
+++ b/web-client/src/pages/OAuthCallbackPage.tsx
@@ -1,16 +1,13 @@
 import { useEffect } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/context/AuthContext";
 
 export function OAuthCallbackPage() {
-    const [searchParams] = useSearchParams();
     const navigate = useNavigate();
+    const { refetch } = useAuth();
 
     useEffect(() => {
-        const token = searchParams.get("token");
-        if (token) {
-            localStorage.setItem("auth_token", token);
-        }
-        navigate("/", { replace: true });
+        refetch().then(() => navigate("/", { replace: true }));
     }, []);
 
     return null;

--- a/web-client/src/pages/RegisterPage.tsx
+++ b/web-client/src/pages/RegisterPage.tsx
@@ -1,34 +1,61 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { Sprout } from "lucide-react";
+import { Sprout, Check, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { registerUser } from "@/api/auth";
+import { useAuth } from "@/context/AuthContext";
+
+const criteria = [
+  { label: "At least 8 characters", test: (p: string) => p.length >= 8 },
+  { label: "One uppercase letter", test: (p: string) => /[A-Z]/.test(p) },
+  { label: "One lowercase letter", test: (p: string) => /[a-z]/.test(p) },
+  { label: "One number",           test: (p: string) => /[0-9]/.test(p) },
+];
 
 export function RegisterPage() {
   const navigate = useNavigate();
+  const { updateUser } = useAuth();
+
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [busy, setBusy] = useState(false);
-  const [passwordError, setPasswordError] = useState("");
+  const [error, setError] = useState("");
+  const [passwordTouched, setPasswordTouched] = useState(false);
+
+  const passwordValid = criteria.every(c => c.test(password));
+  const passwordMismatch = confirmPassword.length > 0 && password !== confirmPassword;
 
   const handleGoogleSignUp = () => {
-    setBusy(true);
-    navigate("/");
+    window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/google`;
   };
 
-  const handleSubmit = (event: React.SyntheticEvent) => {
+  const handleSubmit = async (event: React.SyntheticEvent) => {
     event.preventDefault();
-    if (password !== confirmPassword) {
-      setPasswordError("Passwords do not match.");
-      return;
-    }
-    setPasswordError("");
+    if (!passwordValid || passwordMismatch) return;
+    setError("");
     setBusy(true);
-    navigate("/");
+    try {
+      const res = await registerUser({ email, password, username });
+      const { id, email: e, username: u } = res.data;
+      if (id && e && u) updateUser({ id, email: e, username: u });
+      navigate("/", { replace: true });
+    } catch (err: any) {
+      const code = err?.response?.data?.code;
+      if (code === "EMAIL_ALREADY_EXISTS") {
+        setError("An account with this email already exists.");
+      } else if (code === "USERNAME_ALREADY_EXISTS") {
+        setError("This username is already taken.");
+      } else {
+        setError("Something went wrong. Please try again.");
+      }
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (
@@ -61,29 +88,16 @@ export function RegisterPage() {
           disabled={busy}
         >
           <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-            <path
-              fill="#4285F4"
-              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.76h3.56c2.08-1.92 3.28-4.74 3.28-8.09z"
-            />
-            <path
-              fill="#34A853"
-              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.56-2.76c-.99.66-2.25 1.06-3.72 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0 0 12 23z"
-            />
-            <path
-              fill="#FBBC05"
-              d="M5.84 14.11A6.6 6.6 0 0 1 5.5 12c0-.73.13-1.44.34-2.11V7.05H2.18A11 11 0 0 0 1 12c0 1.78.43 3.46 1.18 4.95l3.66-2.84z"
-            />
-            <path
-              fill="#EA4335"
-              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1A11 11 0 0 0 2.18 7.05l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z"
-            />
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.76h3.56c2.08-1.92 3.28-4.74 3.28-8.09z" />
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.56-2.76c-.99.66-2.25 1.06-3.72 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0 0 12 23z" />
+            <path fill="#FBBC05" d="M5.84 14.11A6.6 6.6 0 0 1 5.5 12c0-.73.13-1.44.34-2.11V7.05H2.18A11 11 0 0 0 1 12c0 1.78.43 3.46 1.18 4.95l3.66-2.84z" />
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1A11 11 0 0 0 2.18 7.05l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z" />
           </svg>
           Continue with Google
         </Button>
 
         <div className="my-5 flex items-center gap-3 text-xs uppercase tracking-widest text-muted-foreground">
-          <span className="h-px flex-1 bg-border" /> or{" "}
-          <span className="h-px flex-1 bg-border" />
+          <span className="h-px flex-1 bg-border" /> or <span className="h-px flex-1 bg-border" />
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-3">
@@ -94,7 +108,7 @@ export function RegisterPage() {
               type="text"
               required
               value={username}
-              onChange={(event) => setUsername(event.target.value)}
+              onChange={e => setUsername(e.target.value)}
             />
           </div>
           <div className="space-y-1.5">
@@ -104,7 +118,7 @@ export function RegisterPage() {
               type="email"
               required
               value={email}
-              onChange={(event) => setEmail(event.target.value)}
+              onChange={e => setEmail(e.target.value)}
             />
           </div>
           <div className="space-y-1.5">
@@ -113,13 +127,22 @@ export function RegisterPage() {
               id="password"
               type="password"
               required
-              minLength={6}
               value={password}
-              onChange={(event) => {
-                setPassword(event.target.value);
-                setPasswordError("");
-              }}
+              onChange={e => { setPassword(e.target.value); setPasswordTouched(true); }}
             />
+            {passwordTouched && (
+              <ul className="mt-2 space-y-1">
+                {criteria.map(c => {
+                  const met = c.test(password);
+                  return (
+                    <li key={c.label} className={`flex items-center gap-1.5 text-xs ${met ? "text-green-600" : "text-muted-foreground"}`}>
+                      {met ? <Check className="h-3 w-3" /> : <X className="h-3 w-3" />}
+                      {c.label}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="confirm-password">Confirm password</Label>
@@ -127,18 +150,19 @@ export function RegisterPage() {
               id="confirm-password"
               type="password"
               required
-              minLength={6}
               value={confirmPassword}
-              onChange={(event) => {
-                setConfirmPassword(event.target.value);
-                setPasswordError("");
-              }}
+              onChange={e => setConfirmPassword(e.target.value)}
             />
-            {passwordError && (
-              <p className="text-xs text-destructive">{passwordError}</p>
+            {passwordMismatch && (
+              <p className="text-xs text-destructive">Passwords do not match.</p>
             )}
           </div>
-          <Button type="submit" className="w-full" disabled={busy}>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={busy || !passwordValid || passwordMismatch}
+          >
             {busy ? "Please wait…" : "Create account"}
           </Button>
         </form>


### PR DESCRIPTION
…ed routes

- DB-backed sessions table (id, user_id, status, expires_at) with Liquibase migration
- SessionService: create, validate (checks active + expiry, updates last_used_at), revoke
- POST /api/v1/auth/login: validates BCrypt password, creates session, sets session_id HttpOnly cookie
- POST /api/v1/auth/logout: revokes session, clears cookie
- GET /api/v1/auth/me: validates session cookie and returns current user
- OAuth2 success handler updated to create DB session and set cookie (instead of JWT)
- RegisterController sets session cookie on successful registration (auto-login)
- React AuthContext with updateUser(), refetch(), logout(), isLoading, isAuthenticated
- ProtectedRoute redirects unauthenticated users to /login, renders null while loading
- LoginPage and RegisterPage wired to real API calls; direct updateUser() call avoids timing race
- AppHeader shows username + sign-out when authenticated, sign-in + get-started when not