### PR TITLE
fix(infra): add missing Google OAuth and frontend URL env vars to Azu…

### DIFF
--- a/infra/docker-compose.azure.yml
+++ b/infra/docker-compose.azure.yml
@@ -47,6 +47,9 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRATION_MS: ${JWT_EXPIRATION_MS}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      FRONTEND_URL: https://${CLIENT_HOST}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.auth.rule=Host(`${SERVER_HOST}`) && PathPrefix(`/api/v1/auth`)"


### PR DESCRIPTION
…re compose

auth-service was missing GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and FRONTEND_URL. Without FRONTEND_URL the OAuth2 success handler redirects to localhost:5273 instead of the production client host, breaking Google login on Azure.