### PR TITLE
feat(infra): add nginx as HTTPS reverse proxy on Azure

### DIFF
--- a/.github/workflows/deploy_azure.yaml
+++ b/.github/workflows/deploy_azure.yaml
@@ -8,18 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: Azure
-      url: 'http://${{ vars.AZURE_PUBLIC_IP }}'
+      url: 'https://${{ vars.AZURE_PUBLIC_IP }}'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Copy Docker Compose File From Repo to VM Host
+      - name: Copy infra directory to VM
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ vars.AZURE_PUBLIC_IP }}
           username: ${{ vars.AZURE_USER }}
           key: ${{ secrets.AZURE_PRIVATE_KEY }}
-          source: "./infra/docker-compose.azure.yml"
+          source: "./infra"
           target: /home/${{ vars.AZURE_USER }}/team-continuous-frustration
 
       - name: SSH to VM and Create .env.prod
@@ -42,9 +42,13 @@ jobs:
             echo "GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env.prod
             echo "GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}" >> .env.prod
 
-            echo "FRONTEND_URL=http://${{ vars.AZURE_PUBLIC_IP }}:3000" >> .env.prod
-            echo "CORS_ALLOWED_ORIGINS=http://${{ vars.AZURE_PUBLIC_IP }}:3000" >> .env.prod
-            echo "VITE_API_BASE_URL=http://${{ vars.AZURE_PUBLIC_IP }}" >> .env.prod
+            echo "LOGOS_API_KEY=${{ secrets.LOGOS_API_KEY }}" >> .env.prod
+            echo "LLM_BASE_URL=${{ vars.LLM_BASE_URL }}" >> .env.prod
+            echo "LLM_MODEL=${{ vars.LLM_MODEL }}" >> .env.prod
+
+            echo "FRONTEND_URL=https://${{ vars.AZURE_PUBLIC_IP }}" >> .env.prod
+            echo "CORS_ALLOWED_ORIGINS=https://${{ vars.AZURE_PUBLIC_IP }}" >> .env.prod
+            echo "VITE_API_BASE_URL=https://${{ vars.AZURE_PUBLIC_IP }}" >> .env.prod
 
       - name: SSH to VM and Execute Docker-Compose Up
         uses: appleboy/ssh-action@v1.0.3
@@ -53,6 +57,11 @@ jobs:
           username: ${{ vars.AZURE_USER }}
           key: ${{ secrets.AZURE_PRIVATE_KEY }}
           script: |
+            echo "Stopping all running containers..."
+            docker stop $(docker ps -q) || true
+            docker rm $(docker ps -aq) || true
+            echo "Pruning unused Docker resources..."
+            docker system prune -af
             echo "Logging into Docker registry..."
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             echo "Starting Docker Compose..."

--- a/infra/docker-compose.azure.yml
+++ b/infra/docker-compose.azure.yml
@@ -107,8 +107,8 @@ services:
 
   api-gateway:
     image: ghcr.io/aet-devops26/team-continuous-frustration/api-gateway:latest
-    ports:
-      - "80:8080"
+    expose:
+      - "8080"
     environment:
       AUTH_SERVICE_URL: http://auth-service:8081
       FLASHCARD_SERVICE_URL: http://flashcard-service:8082
@@ -122,13 +122,29 @@ services:
 
   web-client:
     image: ghcr.io/aet-devops26/team-continuous-frustration/web-client:latest
-    ports:
-      - "3000:80"
+    expose:
+      - "80"
     depends_on:
       - api-gateway
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/generate-certs.sh:/generate-certs.sh:ro
+      - nginx_certs:/etc/nginx/certs
+    entrypoint: ["/bin/sh", "/generate-certs.sh"]
+    depends_on:
+      - api-gateway
+      - web-client
     restart: unless-stopped
 
 volumes:
   postgres_data:
   weaviate_data:
   ollama_data:
+  nginx_certs:

--- a/infra/nginx/generate-certs.sh
+++ b/infra/nginx/generate-certs.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+if [ ! -f /etc/nginx/certs/cert.pem ]; then
+    mkdir -p /etc/nginx/certs
+    openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+        -keyout /etc/nginx/certs/key.pem \
+        -out /etc/nginx/certs/cert.pem \
+        -subj "/CN=localhost"
+fi
+
+exec nginx -g 'daemon off;'

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,35 @@
+server {
+    listen 80;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate /etc/nginx/certs/cert.pem;
+    ssl_certificate_key /etc/nginx/certs/key.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    client_max_body_size 100M;
+
+    location /api/ {
+        proxy_pass http://api-gateway:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_read_timeout 300s;
+    }
+
+    location / {
+        proxy_pass http://web-client:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
Replace direct port exposure with nginx terminating TLS (self-signed cert, auto-generated on first start) and proxying / to web-client and /api/ to api-gateway. HTTP redirects to HTTPS. Also copies full infra/ dir in deploy so nginx config and ollama.sh land on the VM, adds prune/stop steps to avoid disk-full and port-conflict failures, and adds missing LLM env vars to .env.prod.