### PR TITLE
fix(infra): add local defaults for all required env vars in docker-co…

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -2,15 +2,15 @@ services:
   db:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init-db:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -21,17 +21,17 @@ services:
       dockerfile: services/auth-service/Dockerfile
       target: dev
     ports:
-      - "${AUTH_SERVICE_PORT}:8081"
+      - "${AUTH_SERVICE_PORT:-8031}:8081"
     environment:
       SERVER_PORT: 8081
       SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/authdb
-      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
-      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
-      JWT_SECRET: ${JWT_SECRET}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-postgres}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      JWT_SECRET: ${JWT_SECRET:-local-dev-jwt-secret-change-in-production-32c}
       JWT_EXPIRATION_MS: ${JWT_EXPIRATION_MS:-900000}
       SESSION_EXPIRATION_MS: ${SESSION_EXPIRATION_MS:-31536000000}
-      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-local-placeholder}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-local-placeholder}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:5273}
     volumes:
       - ../services/auth-service:/app/services/auth-service
@@ -47,13 +47,13 @@ services:
       dockerfile: services/flashcard-service/Dockerfile
       target: dev
     ports:
-      - "${FLASHCARD_SERVICE_PORT}:8082"
+      - "${FLASHCARD_SERVICE_PORT:-8082}:8082"
     environment:
       SERVER_PORT: 8082
       SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/flashcarddb
-      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
-      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
-      JWT_SECRET: ${JWT_SECRET}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-postgres}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      JWT_SECRET: ${JWT_SECRET:-local-dev-jwt-secret-change-in-production-32c}
     volumes:
       - ../services/flashcard-service:/app/services/flashcard-service
       - ../api:/app/api
@@ -68,14 +68,14 @@ services:
       dockerfile: Dockerfile
       target: service
     ports:
-      - "${GENAI_SERVICE_PORT}:8090"
+      - "${GENAI_SERVICE_PORT:-8090}:8090"
     environment:
-      LOGOS_API_KEY: ${LOGOS_API_KEY}
-      LLM_BASE_URL: ${LLM_BASE_URL}
-      LLM_MODEL: ${LLM_MODEL}
+      LOGOS_API_KEY: ${LOGOS_API_KEY:-}
+      LLM_BASE_URL: ${LLM_BASE_URL:-http://ollama:11434/v1}
+      LLM_MODEL: ${LLM_MODEL:-llama3.2}
       WEAVIATE_URL: http://weaviate:8080
       OLLAMA_API_ENDPOINT: http://ollama:11434
-      JWT_SECRET: ${JWT_SECRET}
+      JWT_SECRET: ${JWT_SECRET:-local-dev-jwt-secret-change-in-production-32c}
     volumes:
       - ../services/genai-service:/app
     depends_on:
@@ -86,7 +86,7 @@ services:
   weaviate:
     image: semitechnologies/weaviate:1.27.0
     ports:
-      - "8080:8080"
+      - "8010:8080"
       - "50051:50051"
     environment:
       QUERY_DEFAULTS_LIMIT: 25
@@ -121,8 +121,8 @@ services:
       POSTGRES_HOST: db
       POSTGRES_PORT: 5432
       POSTGRES_DB: uploaddocumentdb
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     volumes:
       - ../services/upload-service:/app
     depends_on:
@@ -141,7 +141,7 @@ services:
       FLASHCARD_SERVICE_URL: http://flashcard-service:8082
       GENAI_SERVICE_URL: http://genai-service:8080
       UPLOAD_SERVICE_URL: http://upload-service:8091
-      JWT_SECRET: ${JWT_SECRET}
+      JWT_SECRET: ${JWT_SECRET:-local-dev-jwt-secret-change-in-production-32c}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:5273,http://localhost:${GATEWAY_PORT:-8088}}
       JAVA_TOOL_OPTIONS: -Djava.net.preferIPv4Stack=true
     volumes:
@@ -158,7 +158,7 @@ services:
     ports:
       - "5273:5173"
     environment:
-      VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:8088}
       CHOKIDAR_USEPOLLING: "true"
       WATCHPACK_POLLING: "true"
     volumes:


### PR DESCRIPTION
…mpose

All previously unset variables now have :-default fallbacks so the stack starts with docker compose up without any .env file. Credentials default to postgres/postgres, JWT secret to a 45-byte dev string, service ports to their internal ports, and VITE_API_BASE_URL to the gateway at :8088. LOGOS_API_KEY defaults to empty so genai-service falls back to ollama.