### PR TITLE
feat(observability): add Prometheus/Grafana/Loki/Jaeger stack (local …

### DIFF
--- a/.github/workflows/deploy_azure.yaml
+++ b/.github/workflows/deploy_azure.yaml
@@ -51,6 +51,9 @@ jobs:
           logos_api_key: "${{ secrets.LOGOS_API_KEY }}"
           llm_base_url: "${{ vars.LLM_BASE_URL }}"
           llm_model: "${{ vars.LLM_MODEL }}"
+          grafana_admin_user: "${{ vars.GRAFANA_ADMIN_USER }}"
+          grafana_admin_password: "${{ secrets.GRAFANA_ADMIN_PASSWORD }}"
+          monitoring_basic_auth_users: "${{ secrets.MONITORING_BASIC_AUTH_USERS }}"
           EOF
 
       - name: Run Ansible playbook

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ docker compose up --build
 | GenAI service | 8090 |
 | Upload service | 8091 |
 | Web client | 5173 |
+| Prometheus | 9090 |
+| Grafana | 3001 |
+| Jaeger UI | 16686 |
+| Loki | 3100 |
 
 To stop all services:
 
@@ -49,6 +53,21 @@ docker compose down -v
 ```
 
 ---
+
+## Observability
+
+`docker compose up` also starts a full monitoring stack (Prometheus, Grafana, Loki/Promtail,
+Jaeger) locally, and the same stack runs on the Azure VM behind Traefik + Basic Auth.
+
+| Tool | Local | Azure |
+|---|---|---|
+| Prometheus | http://localhost:9090 | `https://prometheus.<vm-ip>.nip.io` |
+| Grafana | http://localhost:3001 (`admin`/`admin`) | `https://grafana.<vm-ip>.nip.io` |
+| Jaeger | http://localhost:16686 | `https://jaeger.<vm-ip>.nip.io` |
+
+**→ See [documents/observability.md](documents/observability.md) for the full guide**: querying
+metrics/logs/traces, the dashboard layout, Azure's two-layer auth and one-time GitHub secrets
+setup, and troubleshooting.
 
 ## Azure VM Deployment
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Jaeger) locally, and the same stack runs on the Azure VM behind Traefik + Basic 
 | Jaeger | http://localhost:16686 | `https://jaeger.<vm-ip>.nip.io` |
 
 **→ See [documents/observability.md](documents/observability.md) for the full guide**: querying
-metrics/logs/traces, the dashboard layout, Azure's two-layer auth and one-time GitHub secrets
-setup, and troubleshooting.
+metrics/logs/traces, the dashboard layout, Azure's auth setup (Basic Auth on all three, plus
+Grafana's own login on top) and one-time GitHub secrets setup, and troubleshooting.
 
 ## Azure VM Deployment
 

--- a/documents/observability.md
+++ b/documents/observability.md
@@ -139,18 +139,18 @@ reachable from a browser, not exposed with default credentials:
 | Prometheus | `https://prometheus.<vm-ip>.nip.io` |
 | Jaeger | `https://jaeger.<vm-ip>.nip.io` |
 
-**Two layers of auth** protect these:
-1. **Traefik HTTP Basic Auth** — required just to load the page. Configured via a Traefik
-   *file-provider* config (`infra/ansible/templates/traefik-dynamic.yml.j2`), rendered by Ansible
-   directly onto the VM — deliberately **not** passed through a docker-compose `${VAR}`, because
-   Compose's env-file interpolation mangles `$` characters found in htpasswd-style hashes
-   (confirmed empirically: `admin:$apr1$abc...` silently collapses to `admin:`). Rendering via
-   Jinja2 sidesteps that entirely.
-2. **Grafana's own login** — a real generated `GRAFANA_ADMIN_USER`/`PASSWORD`, not local's
-   `admin`/`admin`.
+All three sit behind **Traefik HTTP Basic Auth** — required just to load the page. Configured
+via a Traefik *file-provider* config (`infra/ansible/templates/traefik-dynamic.yml.j2`), rendered
+by Ansible directly onto the VM — deliberately **not** passed through a docker-compose `${VAR}`,
+because Compose's env-file interpolation mangles `$` characters found in htpasswd-style hashes
+(confirmed empirically: `admin:$apr1$abc...` silently collapses to `admin:`). Rendering via
+Jinja2 sidesteps that entirely.
 
-Prometheus and Jaeger have no login of their own — Basic Auth is their *only* protection, so
-don't skip setting it up.
+**Grafana alone gets a second layer** on top of that: its own login, a real generated
+`GRAFANA_ADMIN_USER`/`PASSWORD`, not local's `admin`/`admin` default.
+
+**Prometheus and Jaeger have no login of their own** — Basic Auth is their *only* protection, so
+don't skip setting up `MONITORING_BASIC_AUTH_USERS`.
 
 ### One-time setup
 

--- a/documents/observability.md
+++ b/documents/observability.md
@@ -1,0 +1,207 @@
+# Observability: Monitoring and Logging
+
+This document covers how to run and use the monitoring stack — metrics, logs, and distributed
+traces — both locally and on the Azure VM. For architecture/service decomposition, see
+[system_structure.md](system_structure.md).
+
+## What's included
+
+| Pillar | Tool | Purpose |
+|---|---|---|
+| Metrics | **Prometheus** | Scrapes request rate/error/latency from every backend service |
+| Dashboards | **Grafana** | Visualizes Prometheus (metrics), Loki (logs), and Jaeger (traces) in one place |
+| Logs | **Loki** + **Promtail** | Aggregates every container's stdout/stderr, queryable by service |
+| Traces | **Jaeger** (OpenTelemetry) | Connects one request across every service it touches |
+
+All 5 backend services are instrumented:
+
+| Service | Metrics endpoint | Tracing |
+|---|---|---|
+| `auth-service`, `flashcard-service`, `api-gateway` (Spring Boot) | `/actuator/prometheus` | Micrometer Tracing → OTLP |
+| `genai-service`, `upload-service` (FastAPI) | `/metrics` | OpenTelemetry SDK → OTLP |
+
+Config lives under `infra/prometheus`, `infra/loki`, `infra/promtail`, and
+`infra/grafana/provisioning` — identical between local and Azure, since both reference services
+purely by in-network container name/port.
+
+---
+
+## Running it locally
+
+```bash
+cd infra
+docker compose up --build
+```
+
+| Tool | URL | Credentials |
+|---|---|---|
+| Prometheus | http://localhost:9090 | none |
+| Grafana | http://localhost:3001 | `admin` / `admin` |
+| Jaeger | http://localhost:16686 | none |
+| Loki | http://localhost:3100 | (no UI — query via Grafana) |
+
+> **Grafana login note:** the field is labeled "Email or username" — type `admin`, not a real
+> email address.
+
+> **Port conflict:** if `redis` fails to start with "port is already allocated", something else
+> on your machine already holds `6379`. The host-side port is configurable —
+> set `REDIS_PORT` in `infra/.env` (see `infra/.env.example`) to any free port; container-to-container
+> traffic always uses `redis:6379` regardless, so nothing else needs to change.
+
+### Checking it's actually working
+
+```bash
+# metrics
+curl http://localhost:8031/actuator/prometheus   # auth-service
+curl http://localhost:8090/metrics                # genai-service
+
+# all Prometheus scrape targets should show "up"
+open http://localhost:9090/targets
+```
+
+---
+
+## Using each pillar
+
+### Metrics — Grafana dashboard
+
+Open Grafana → **Dashboards** → **Service Overview (RED Method)**. It follows the RED method
+(Rate, Errors, Duration) taught for service-level metrics, split by stack since the two frameworks
+expose different metric names:
+
+- **Spring services** (`http_server_requests_seconds_*`): Request Rate, Error Rate (5xx), Client
+  Error Rate (4xx), P95 Latency.
+- **Python services** (`http_requests_total`, `http_request_duration_seconds_*`): same four panels.
+- A **Logs** panel at the bottom, pulling from Loki.
+
+The dashboard auto-refreshes every 30s. If a panel says "No data", that's often correct — it
+means literally zero matching requests occurred yet (e.g. a service's 5xx panel is empty until
+something actually errors), not that the panel is broken.
+
+Useful raw PromQL (Prometheus → Graph, or Grafana → Explore → Prometheus):
+```
+sum by (job) (rate(http_server_requests_seconds_count[5m]))
+histogram_quantile(0.95, sum by (job, le) (rate(http_server_requests_seconds_bucket[5m])))
+```
+
+### Logs — Grafana Explore → Loki
+
+Log streams are labeled `service`, `container`, and `project` (there is **no** `job` label on
+Loki streams — that's a Prometheus-only convention, don't confuse the two).
+
+```
+{service="auth-service"}
+{service="auth-service"} |~ "(?i)error|exception"
+{service=~".+"}                          # everything
+```
+
+Click **Live** (top right, next to the time picker) to stream new lines as they arrive instead of
+a fixed window.
+
+### Traces — Jaeger
+
+Open Jaeger → pick a **Service** (e.g. `api-gateway`) → **Find Traces**. Click into one to see
+the span waterfall across every service the request touched. To find failed requests
+specifically, search with tag `error=true`.
+
+Traces, logs, and metrics correlate by timestamp: pick a slow/failed trace in Jaeger, note its
+time, then narrow Loki's time range to the same window to see exactly what each service logged
+during that request.
+
+### Generating test traffic
+
+There's no built-in load generator; a simple loop against the gateway is enough to populate the
+dashboards:
+```bash
+while true; do
+  curl -s -o /dev/null -X POST http://localhost:8088/api/v1/auth/register \
+    -H "Content-Type: application/json" \
+    -d '{"email":"test@example.com","password":"Password123!","username":"test"}'
+  sleep 2
+done
+```
+To specifically populate error panels, send requests that are *expected* to fail: wrong
+passwords (401), duplicate registrations (409), malformed bodies (422), unknown routes (404). Note
+some of these are **client errors (4xx)**, tracked in a separate dashboard panel from **server
+errors (5xx)** — a 4xx is the caller's fault, a 5xx means the service itself broke.
+
+---
+
+## Running it on Azure
+
+The same stack runs on the Azure VM via `docker-compose.azure.yml`, deployed by
+`infra/ansible/playbook.yml` through the `Deploy Docker Images` GitHub Action. Unlike local, it's
+reachable from a browser, not exposed with default credentials:
+
+| Tool | URL |
+|---|---|
+| Grafana | `https://grafana.<vm-ip>.nip.io` |
+| Prometheus | `https://prometheus.<vm-ip>.nip.io` |
+| Jaeger | `https://jaeger.<vm-ip>.nip.io` |
+
+**Two layers of auth** protect these:
+1. **Traefik HTTP Basic Auth** — required just to load the page. Configured via a Traefik
+   *file-provider* config (`infra/ansible/templates/traefik-dynamic.yml.j2`), rendered by Ansible
+   directly onto the VM — deliberately **not** passed through a docker-compose `${VAR}`, because
+   Compose's env-file interpolation mangles `$` characters found in htpasswd-style hashes
+   (confirmed empirically: `admin:$apr1$abc...` silently collapses to `admin:`). Rendering via
+   Jinja2 sidesteps that entirely.
+2. **Grafana's own login** — a real generated `GRAFANA_ADMIN_USER`/`PASSWORD`, not local's
+   `admin`/`admin`.
+
+Prometheus and Jaeger have no login of their own — Basic Auth is their *only* protection, so
+don't skip setting it up.
+
+### One-time setup
+
+Before the first deploy that includes this stack, add to the repo's `Azure` GitHub environment:
+
+| Type | Name | Value |
+|---|---|---|
+| Variable | `GRAFANA_ADMIN_USER` | e.g. `admin` |
+| Secret | `GRAFANA_ADMIN_PASSWORD` | a real random password (avoid `$` — this one *does* go through plain compose interpolation) |
+| Secret | `MONITORING_BASIC_AUTH_USERS` | output of the command below |
+
+Generate a password and its htpasswd hash locally (prefer running these yourself via `!` so the
+password never lands in a chat transcript, and use `htpasswd`'s interactive prompt so it's not
+saved in shell history either):
+```bash
+LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32; echo   # for GRAFANA_ADMIN_PASSWORD
+htpasswd -nB admin                                              # prompts for password, no echo
+# or, without httpd-tools installed:
+echo "admin:$(openssl passwd -apr1 'your-password')"
+```
+Paste the full `admin:$2y$...` (or `$apr1$...`) line as the `MONITORING_BASIC_AUTH_USERS` secret.
+
+Until these three exist, the `Deploy Docker Images` workflow will fail (or Traefik will error on
+an empty middleware) — this is intentional; production secrets in this repo are never given
+silent local-style defaults (see the "Azure vs. local env var philosophy" note below).
+
+### Azure vs. local env var philosophy
+
+`docker-compose.yml` (local) gives every variable a `:-default` fallback so a fresh clone runs
+with zero setup — this was a deliberate fix (commit `1362d2b`) after a past incident where a
+missing `.env` file broke a grader's run. `docker-compose.azure.yml` intentionally does the
+**opposite**: no defaults for secrets (`POSTGRES_PASSWORD`, `JWT_SECRET`,
+`GOOGLE_CLIENT_SECRET`, and now `GRAFANA_ADMIN_PASSWORD` all require a real value). This is safe
+specifically because Azure only ever runs through the Ansible pipeline with a fully-populated
+`.env.prod` — never cloned-and-run ad hoc — so there's no equivalent failure mode to guard against
+there.
+
+---
+
+## Troubleshooting
+
+- **A panel says "No data"** — check whether any request has actually hit that status/service
+  yet; `sum by (job, status) (http_server_requests_seconds_count)` in Prometheus shows every
+  status code seen per job.
+- **`{job="..."}` returns nothing in Loki** — Loki streams here use `service`/`container`/`project`
+  labels, not `job`. Use `curl http://localhost:3100/loki/api/v1/labels` to see what's actually
+  available.
+- **A service's error shows up on `api-gateway` but not the service itself** — the gateway can
+  generate its own 5xx (e.g. a transient connection failure calling a downstream service) that
+  never touched that service at all; check Loki for which container actually logged the
+  exception.
+- **`redis` (or any container) fails with "port is already allocated"** — something else on the
+  host already holds that port; override the host-side mapping via the corresponding `*_PORT`
+  variable in `infra/.env`, container-to-container traffic is unaffected.

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -14,6 +14,9 @@ FLASHCARD_SERVICE_PORT=8082
 # API Gateway
 GATEWAY_PORT=8090
 WEAVIATE_PORT=8080
+
+# Redis (host port only; container-to-container traffic always uses redis:6379)
+REDIS_PORT=6380
 CORS_ALLOWED_ORIGINS=http://localhost:8080,http://localhost:5173
 LOGOS_API_KEY=your-logos-api-key-here
 LLM_BASE_URL=http://ollama:11434/v1

--- a/infra/ansible/playbook.yml
+++ b/infra/ansible/playbook.yml
@@ -99,6 +99,21 @@
         owner: "{{ ansible_user }}"
         mode: preserve
 
+    - name: Ensure Traefik dynamic config directory exists
+      ansible.builtin.file:
+        path: "{{ infra_dir }}/traefik/dynamic"
+        state: directory
+        owner: "{{ ansible_user }}"
+        mode: "0755"
+
+    - name: Render Traefik dynamic config (monitoring basic auth)
+      ansible.builtin.template:
+        src: templates/traefik-dynamic.yml.j2
+        dest: "{{ infra_dir }}/traefik/dynamic/monitoring-auth.yml"
+        owner: "{{ ansible_user }}"
+        mode: "0600"
+      no_log: true
+
     - name: Render production environment file
       ansible.builtin.template:
         src: templates/env.prod.j2

--- a/infra/ansible/playbook.yml
+++ b/infra/ansible/playbook.yml
@@ -99,6 +99,34 @@
         owner: "{{ ansible_user }}"
         mode: preserve
 
+    - name: Copy Prometheus config to VM
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../prometheus/"
+        dest: "{{ infra_dir }}/prometheus/"
+        owner: "{{ ansible_user }}"
+        mode: preserve
+
+    - name: Copy Loki config to VM
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../loki/"
+        dest: "{{ infra_dir }}/loki/"
+        owner: "{{ ansible_user }}"
+        mode: preserve
+
+    - name: Copy Promtail config to VM
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../promtail/"
+        dest: "{{ infra_dir }}/promtail/"
+        owner: "{{ ansible_user }}"
+        mode: preserve
+
+    - name: Copy Grafana provisioning config to VM
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../grafana/"
+        dest: "{{ infra_dir }}/grafana/"
+        owner: "{{ ansible_user }}"
+        mode: preserve
+
     - name: Ensure Traefik dynamic config directory exists
       ansible.builtin.file:
         path: "{{ infra_dir }}/traefik/dynamic"

--- a/infra/ansible/templates/env.prod.j2
+++ b/infra/ansible/templates/env.prod.j2
@@ -15,3 +15,6 @@ LLM_MODEL={{ llm_model }}
 FRONTEND_URL={{ azure_public_ip }}.nip.io
 CORS_ALLOWED_ORIGINS=https://{{ azure_public_ip }}.nip.io
 VITE_API_BASE_URL=https://{{ azure_public_ip }}.nip.io
+
+GRAFANA_ADMIN_USER={{ grafana_admin_user }}
+GRAFANA_ADMIN_PASSWORD={{ grafana_admin_password }}

--- a/infra/ansible/templates/traefik-dynamic.yml.j2
+++ b/infra/ansible/templates/traefik-dynamic.yml.j2
@@ -1,0 +1,6 @@
+http:
+  middlewares:
+    monitoring-auth:
+      basicAuth:
+        users:
+          - "{{ monitoring_basic_auth_users }}"

--- a/infra/docker-compose.azure.yml
+++ b/infra/docker-compose.azure.yml
@@ -4,6 +4,8 @@ services:
     command:
       - "--providers.docker=true"
       - "--providers.docker.exposedByDefault=false"
+      - "--providers.file.directory=/etc/traefik/dynamic"
+      - "--providers.file.watch=true"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
       - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
@@ -19,6 +21,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./letsencrypt:/letsencrypt
+      - ./traefik/dynamic:/etc/traefik/dynamic:ro
 
   db:
     image: postgres:16-alpine
@@ -188,8 +191,86 @@ services:
       - "traefik.http.routers.webclient.tls.certresolver=letsencrypt"
       - "traefik.http.routers.webclient.priority=1"
 
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    volumes:
+      - ./prometheus:/etc/prometheus:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.prometheus.rule=Host(`prometheus.${FRONTEND_URL}`)"
+      - "traefik.http.services.prometheus.loadbalancer.server.port=9090"
+      - "traefik.http.routers.prometheus.entrypoints=websecure"
+      - "traefik.http.routers.prometheus.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.prometheus.middlewares=monitoring-auth@file"
+
+  loki:
+    image: grafana/loki:2.9.0
+    expose:
+      - "3100"
+    volumes:
+      - ./loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/loki-config.yaml
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:2.9.0
+    volumes:
+      - ./promtail/promtail-config.yaml:/etc/promtail/promtail-config.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    command: -config.file=/etc/promtail/promtail-config.yaml
+    depends_on:
+      - loki
+    restart: unless-stopped
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    expose:
+      - "4317"
+      - "4318"
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.jaeger.rule=Host(`jaeger.${FRONTEND_URL}`)"
+      - "traefik.http.services.jaeger.loadbalancer.server.port=16686"
+      - "traefik.http.routers.jaeger.entrypoints=websecure"
+      - "traefik.http.routers.jaeger.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.jaeger.middlewares=monitoring-auth@file"
+
+  grafana:
+    image: grafana/grafana-oss:latest
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    depends_on:
+      - prometheus
+      - loki
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.grafana.rule=Host(`grafana.${FRONTEND_URL}`)"
+      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+      - "traefik.http.routers.grafana.entrypoints=websecure"
+      - "traefik.http.routers.grafana.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.grafana.middlewares=monitoring-auth@file"
+
 volumes:
   postgres_data:
   weaviate_data:
   ollama_data:
   redis_data:
+  prometheus_data:
+  grafana_data:
+  loki_data:

--- a/infra/docker-compose.azure.yml
+++ b/infra/docker-compose.azure.yml
@@ -50,6 +50,7 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRATION_MS: ${JWT_EXPIRATION_MS:-900000}
+      TRACING_SAMPLING_PROBABILITY: ${TRACING_SAMPLING_PROBABILITY:-0.1}
       SESSION_EXPIRATION_MS: ${SESSION_EXPIRATION_MS:-31536000000}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-placeholder}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-placeholder}
@@ -75,6 +76,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
+      TRACING_SAMPLING_PROBABILITY: ${TRACING_SAMPLING_PROBABILITY:-0.1}
     depends_on:
       db:
         condition: service_healthy
@@ -158,6 +160,7 @@ services:
       GENAI_SERVICE_URL: http://genai-service:8090
       UPLOAD_SERVICE_URL: http://upload-service:8091
       JWT_SECRET: ${JWT_SECRET}
+      TRACING_SAMPLING_PROBABILITY: ${TRACING_SAMPLING_PROBABILITY:-0.1}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost}
       JAVA_TOOL_OPTIONS: -Djava.net.preferIPv4Stack=true
     depends_on:
@@ -222,6 +225,7 @@ services:
     image: grafana/promtail:2.9.0
     volumes:
       - ./promtail/promtail-config.yaml:/etc/promtail/promtail-config.yaml:ro
+      - promtail_positions:/data
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
     command: -config.file=/etc/promtail/promtail-config.yaml
@@ -274,3 +278,4 @@ volumes:
   prometheus_data:
   grafana_data:
   loki_data:
+  promtail_positions:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       WEAVIATE_URL: http://weaviate:8080
       REDIS_URL: redis://redis:6379/0
       JWT_SECRET: ${JWT_SECRET:-local-dev-jwt-secret-change-in-production-32c}
+      OTLP_EXPORTER_ENDPOINT: jaeger:4317
     volumes:
       - ../services/genai-service:/app
     depends_on:
@@ -86,6 +87,7 @@ services:
       - ollama
       - upload-service
       - redis
+      - jaeger
 
   weaviate:
     image: semitechnologies/weaviate:1.27.0
@@ -117,7 +119,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6380}:6379"
     volumes:
       - redis_data:/data
 
@@ -134,11 +136,14 @@ services:
       POSTGRES_DB: uploaddocumentdb
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      OTLP_EXPORTER_ENDPOINT: jaeger:4317
     volumes:
       - ../services/upload-service:/app
     depends_on:
       db:
         condition: service_healthy
+      jaeger:
+        condition: service_started
 
   api-gateway:
     build:
@@ -178,6 +183,65 @@ services:
     depends_on:
       - api-gateway
 
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus:/etc/prometheus:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:2.9.0
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/loki-config.yaml
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:2.9.0
+    volumes:
+      - ./promtail/promtail-config.yaml:/etc/promtail/promtail-config.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    command: -config.file=/etc/promtail/promtail-config.yaml
+    depends_on:
+      - loki
+    restart: unless-stopped
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana-oss:latest
+    ports:
+      - "3001:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    depends_on:
+      - prometheus
+      - loki
+    restart: unless-stopped
+
 volumes:
   postgres_data:
   weaviate_data:
@@ -185,3 +249,6 @@ volumes:
   redis_data:
   maven_cache:
   web_client_node_modules:
+  prometheus_data:
+  grafana_data:
+  loki_data:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -209,6 +209,7 @@ services:
     image: grafana/promtail:2.9.0
     volumes:
       - ./promtail/promtail-config.yaml:/etc/promtail/promtail-config.yaml:ro
+      - promtail_positions:/data
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
     command: -config.file=/etc/promtail/promtail-config.yaml
@@ -252,3 +253,4 @@ volumes:
   prometheus_data:
   grafana_data:
   loki_data:
+  promtail_positions:

--- a/infra/grafana/provisioning/dashboards/dashboards.yml
+++ b/infra/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+providers:
+  - name: "default"
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/infra/grafana/provisioning/dashboards/service-overview.json
+++ b/infra/grafana/provisioning/dashboards/service-overview.json
@@ -1,0 +1,138 @@
+{
+  "title": "Service Overview (RED Method)",
+  "uid": "service-overview",
+  "editable": true,
+  "schemaVersion": 39,
+  "timezone": "browser",
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Spring Services - Request Rate",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (job) (rate(http_server_requests_seconds_count[5m]))",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Spring Services - Error Rate (5xx)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (job) (rate(http_server_requests_seconds_count{status=~\"5..\"}[5m]))",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Spring Services - Client Error Rate (4xx)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (job, status) (rate(http_server_requests_seconds_count{status=~\"4..\"}[5m]))",
+          "legendFormat": "{{job}} {{status}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Spring Services - P95 Latency",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (job, le) (rate(http_server_requests_seconds_bucket[5m])))",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Python Services - Request Rate",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (job) (rate(http_requests_total[5m]))",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Python Services - Error Rate (5xx)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (job) (rate(http_requests_total{status=~\"5..\"}[5m]))",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Python Services - Client Error Rate (4xx)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (job) (rate(http_requests_total{status=~\"4..\"}[5m]))",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Python Services - P95 Latency",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (job, le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Logs - All Services",
+      "type": "logs",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 32 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{service=~\".+\"}"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/provisioning/datasources/datasources.yaml
+++ b/infra/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,23 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    jsonData:
+      maxLines: 1000
+
+  - name: Jaeger
+    uid: jaeger
+    type: jaeger
+    access: proxy
+    url: http://jaeger:16686

--- a/infra/loki/loki-config.yaml
+++ b/infra/loki/loki-config.yaml
@@ -1,0 +1,26 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,33 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "auth-service"
+    metrics_path: "/actuator/prometheus"
+    static_configs:
+      - targets: ["auth-service:8081"]
+
+  - job_name: "flashcard-service"
+    metrics_path: "/actuator/prometheus"
+    static_configs:
+      - targets: ["flashcard-service:8082"]
+
+  - job_name: "api-gateway"
+    metrics_path: "/actuator/prometheus"
+    static_configs:
+      - targets: ["api-gateway:8080"]
+
+  - job_name: "genai-service"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["genai-service:8090"]
+
+  - job_name: "upload-service"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["upload-service:8091"]

--- a/infra/promtail/promtail-config.yaml
+++ b/infra/promtail/promtail-config.yaml
@@ -3,7 +3,7 @@ server:
   grpc_listen_port: 0
 
 positions:
-  filename: /tmp/positions.yaml
+  filename: /data/positions.yaml
 
 clients:
   - url: http://loki:3100/loki/api/v1/push

--- a/infra/promtail/promtail-config.yaml
+++ b/infra/promtail/promtail-config.yaml
@@ -1,0 +1,23 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_name"]
+        regex: "/(.*)"
+        target_label: "container"
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: "service"
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_project"]
+        target_label: "project"

--- a/services/api-gateway/pom.xml
+++ b/services/api-gateway/pom.xml
@@ -33,6 +33,18 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>

--- a/services/api-gateway/src/main/resources/application.yml
+++ b/services/api-gateway/src/main/resources/application.yml
@@ -55,7 +55,7 @@ management:
         include: health,info,prometheus
   tracing:
     sampling:
-      probability: 1.0
+      probability: ${TRACING_SAMPLING_PROBABILITY:1.0}
   otlp:
     tracing:
       endpoint: ${OTLP_TRACING_ENDPOINT:http://jaeger:4318/v1/traces}

--- a/services/api-gateway/src/main/resources/application.yml
+++ b/services/api-gateway/src/main/resources/application.yml
@@ -52,4 +52,14 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,prometheus
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: ${OTLP_TRACING_ENDPOINT:http://jaeger:4318/v1/traces}
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true

--- a/services/auth-service/pom.xml
+++ b/services/auth-service/pom.xml
@@ -49,6 +49,18 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>

--- a/services/auth-service/src/main/java/com/devops/authservice/config/SecurityConfig.java
+++ b/services/auth-service/src/main/java/com/devops/authservice/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
-                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/services/auth-service/src/main/resources/application.properties
+++ b/services/auth-service/src/main/resources/application.properties
@@ -1,7 +1,11 @@
 server.port=${SERVER_PORT:8081}
 server.forward-headers-strategy=framework
-management.endpoints.web.exposure.include=health,info
+spring.application.name=auth-service
+management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=always
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.tracing.sampling.probability=1.0
+management.otlp.tracing.endpoint=${OTLP_TRACING_ENDPOINT:http://jaeger:4318/v1/traces}
 
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/authdb}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:auth}

--- a/services/auth-service/src/main/resources/application.properties
+++ b/services/auth-service/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.application.name=auth-service
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=always
 management.metrics.distribution.percentiles-histogram.http.server.requests=true
-management.tracing.sampling.probability=1.0
+management.tracing.sampling.probability=${TRACING_SAMPLING_PROBABILITY:1.0}
 management.otlp.tracing.endpoint=${OTLP_TRACING_ENDPOINT:http://jaeger:4318/v1/traces}
 
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/authdb}

--- a/services/flashcard-service/pom.xml
+++ b/services/flashcard-service/pom.xml
@@ -41,6 +41,18 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>

--- a/services/flashcard-service/src/main/java/com/devops/springservice/security/SecurityConfig.java
+++ b/services/flashcard-service/src/main/java/com/devops/springservice/security/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/flashcards/health", "/actuator/health", "/actuator/info", "/error").permitAll()
+                        .requestMatchers("/api/v1/flashcards/health", "/actuator/health", "/actuator/info", "/actuator/prometheus", "/error").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(e -> e

--- a/services/flashcard-service/src/main/resources/application.properties
+++ b/services/flashcard-service/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.application.name=flashcard-service
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=always
 management.metrics.distribution.percentiles-histogram.http.server.requests=true
-management.tracing.sampling.probability=1.0
+management.tracing.sampling.probability=${TRACING_SAMPLING_PROBABILITY:1.0}
 management.otlp.tracing.endpoint=${OTLP_TRACING_ENDPOINT:http://jaeger:4318/v1/traces}
 
 spring.datasource.url=jdbc:postgresql://localhost:5432/flashcarddb

--- a/services/flashcard-service/src/main/resources/application.properties
+++ b/services/flashcard-service/src/main/resources/application.properties
@@ -1,7 +1,11 @@
 server.port=${SERVER_PORT:8082}
 jwt.secret=${JWT_SECRET:change-me-in-production-min-32-chars!!}
-management.endpoints.web.exposure.include=health,info
+spring.application.name=flashcard-service
+management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=always
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.tracing.sampling.probability=1.0
+management.otlp.tracing.endpoint=${OTLP_TRACING_ENDPOINT:http://jaeger:4318/v1/traces}
 
 spring.datasource.url=jdbc:postgresql://localhost:5432/flashcarddb
 spring.datasource.username=flashcard

--- a/services/genai-service/requirements.txt
+++ b/services/genai-service/requirements.txt
@@ -41,3 +41,7 @@ langchain_text_splitters
 langchain_ollama
 langchain-weaviate
 redis
+prometheus-fastapi-instrumentator
+opentelemetry-sdk
+opentelemetry-exporter-otlp
+opentelemetry-instrumentation-fastapi

--- a/services/genai-service/src/openapi_server/main.py
+++ b/services/genai-service/src/openapi_server/main.py
@@ -1,5 +1,14 @@
 # coding: utf-8
+import os
+
 from fastapi import FastAPI
+from prometheus_fastapi_instrumentator import Instrumentator
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from openapi_server.impl.controller import router as DefaultApiRouter
 
@@ -18,3 +27,18 @@ app = FastAPI(
 )
 
 app.include_router(DefaultApiRouter)
+
+Instrumentator().instrument(app).expose(app)
+
+trace.set_tracer_provider(
+    TracerProvider(resource=Resource.create({SERVICE_NAME: "genai-service"}))
+)
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(
+        OTLPSpanExporter(
+            endpoint=os.getenv("OTLP_EXPORTER_ENDPOINT", "jaeger:4317"),
+            insecure=True,
+        )
+    )
+)
+FastAPIInstrumentor.instrument_app(app)

--- a/services/upload-service/requirements.txt
+++ b/services/upload-service/requirements.txt
@@ -35,3 +35,7 @@ watchgod==0.7
 websockets==10.0
 markitdown
 psycopg2
+prometheus-fastapi-instrumentator
+opentelemetry-sdk
+opentelemetry-exporter-otlp
+opentelemetry-instrumentation-fastapi

--- a/services/upload-service/src/openapi_server/main.py
+++ b/services/upload-service/src/openapi_server/main.py
@@ -1,6 +1,15 @@
 # coding: utf-8
 
+import os
+
 from fastapi import FastAPI
+from prometheus_fastapi_instrumentator import Instrumentator
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from openapi_server.impl.controller import router as DefaultApiRouter
 
@@ -11,3 +20,18 @@ app = FastAPI(
 )
 
 app.include_router(DefaultApiRouter)
+
+Instrumentator().instrument(app).expose(app)
+
+trace.set_tracer_provider(
+    TracerProvider(resource=Resource.create({SERVICE_NAME: "upload-service"}))
+)
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(
+        OTLPSpanExporter(
+            endpoint=os.getenv("OTLP_EXPORTER_ENDPOINT", "jaeger:4317"),
+            insecure=True,
+        )
+    )
+)
+FastAPIInstrumentor.instrument_app(app)


### PR DESCRIPTION
…+ Azure)

Instruments all 5 backend services with metrics (Micrometer/Actuator for Spring, prometheus-fastapi-instrumentator for FastAPI) and distributed tracing (OpenTelemetry -> Jaeger), and wires up Prometheus, Grafana (pre-provisioned datasources + a RED-method dashboard), and Loki/Promtail for log aggregation via docker-compose.

Extends the same stack to the Azure VM behind Traefik + HTTP Basic Auth (rendered via a Traefik file-provider config through Ansible, avoiding a confirmed docker-compose env-file bug that mangles $ characters in htpasswd hashes), plus real Grafana admin credentials instead of the local admin/admin default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end observability with Prometheus metrics, Grafana dashboards, Loki logs, and Jaeger distributed tracing.
  * Added service health, request-rate, error-rate, latency, log, and trace visibility across local and Azure environments.
  * Added protected monitoring access and configurable Grafana credentials for Azure deployments.
  * Added configurable host-side Redis port to avoid local conflicts.

* **Documentation**
  * Added setup, usage, access, troubleshooting, and Azure deployment guidance for the monitoring stack.
  * Updated service startup and monitoring URL references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->