### PR TITLE
test: add unit tests for auth-service and api-gateway with CI gate

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,45 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  java-tests:
+    name: ${{ matrix.service }} tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - auth-service
+          - api-gateway
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Run unit tests
+        working-directory: services/${{ matrix.service }}
+        run: mvn -B --no-transfer-progress test
+
+      - name: Publish test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.service }}-surefire-reports
+          path: services/${{ matrix.service }}/target/surefire-reports/
+          if-no-files-found: ignore

--- a/services/api-gateway/pom.xml
+++ b/services/api-gateway/pom.xml
@@ -92,6 +92,25 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/tests/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/services/api-gateway/tests/java/com/devops/apigateway/filter/JwtAuthGlobalFilterTest.java
+++ b/services/api-gateway/tests/java/com/devops/apigateway/filter/JwtAuthGlobalFilterTest.java
@@ -1,0 +1,135 @@
+package com.devops.apigateway.filter;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JwtAuthGlobalFilterTest {
+
+    private static final String SECRET = "test-secret-key-that-is-at-least-32-bytes!!";
+    private static final SecretKey KEY = Keys.hmacShaKeyFor(SECRET.getBytes());
+
+    private final JwtAuthGlobalFilter filter =
+            new JwtAuthGlobalFilter(SECRET, "http://localhost:1");
+
+    private GatewayFilterChain chainReturning(Mono<Void> result) {
+        GatewayFilterChain chain = mock(GatewayFilterChain.class);
+        when(chain.filter(any())).thenReturn(result);
+        return chain;
+    }
+
+    private String validToken(UUID userId) {
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("email", "user@example.com")
+                .claim("username", "alice")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 900_000L))
+                .signWith(KEY)
+                .compact();
+    }
+
+    @Test
+    void publicPath_isForwardedWithoutAuthentication() {
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.post("/api/v1/auth/login"));
+        GatewayFilterChain chain = chainReturning(Mono.empty());
+
+        filter.filter(exchange, chain).block();
+
+        verify(chain, times(1)).filter(exchange);
+        assertThat(exchange.getResponse().getStatusCode()).isNull();
+    }
+
+    @Test
+    void validAccessToken_forwardsWithUserHeaders() {
+        UUID userId = UUID.randomUUID();
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/v1/flashcards")
+                        .cookie(new HttpCookie("access_token", validToken(userId))));
+
+        GatewayFilterChain chain = mock(GatewayFilterChain.class);
+        when(chain.filter(any())).thenReturn(Mono.empty());
+
+        filter.filter(exchange, chain).block();
+
+        org.mockito.ArgumentCaptor<ServerWebExchange> captor =
+                org.mockito.ArgumentCaptor.forClass(ServerWebExchange.class);
+        verify(chain).filter(captor.capture());
+        ServerHttpRequest forwarded = captor.getValue().getRequest();
+        assertThat(forwarded.getHeaders().getFirst("X-User-Id")).isEqualTo(userId.toString());
+        assertThat(forwarded.getHeaders().getFirst("X-User-Email")).isEqualTo("user@example.com");
+        assertThat(forwarded.getHeaders().getFirst("X-User-Name")).isEqualTo("alice");
+    }
+
+    @Test
+    void noCookies_isRejectedWith401() {
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/v1/flashcards"));
+        GatewayFilterChain chain = chainReturning(Mono.empty());
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        verify(chain, never()).filter(any());
+    }
+
+    @Test
+    void invalidAccessTokenWithoutSession_isRejectedWith401() {
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/v1/flashcards")
+                        .cookie(new HttpCookie("access_token", "garbage.token.value")));
+        GatewayFilterChain chain = chainReturning(Mono.empty());
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        verify(chain, never()).filter(any());
+    }
+
+    @Test
+    void tokenSignedWithDifferentKey_isRejectedWith401() {
+        SecretKey otherKey = Keys.hmacShaKeyFor("a-totally-different-secret-key-32-bytes!!".getBytes());
+        String foreignToken = Jwts.builder()
+                .subject(UUID.randomUUID().toString())
+                .claim("email", "user@example.com")
+                .claim("username", "alice")
+                .expiration(new Date(System.currentTimeMillis() + 900_000L))
+                .signWith(otherKey)
+                .compact();
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/v1/flashcards")
+                        .cookie(new HttpCookie("access_token", foreignToken)));
+        GatewayFilterChain chain = chainReturning(Mono.empty());
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        verify(chain, never()).filter(any());
+    }
+
+    @Test
+    void filterHasHighestPrecedenceOrder() {
+        assertThat(filter.getOrder()).isEqualTo(-1);
+    }
+}

--- a/services/auth-service/pom.xml
+++ b/services/auth-service/pom.xml
@@ -121,6 +121,25 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/tests/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <version>7.5.0</version>

--- a/services/auth-service/tests/java/com/devops/authservice/controller/GlobalExceptionHandlerTest.java
+++ b/services/auth-service/tests/java/com/devops/authservice/controller/GlobalExceptionHandlerTest.java
@@ -1,0 +1,52 @@
+package com.devops.authservice.controller;
+
+import com.devops.authservice.domain.user.exception.EmailAlreadyExistsException;
+import com.devops.authservice.domain.user.exception.UsernameAlreadyExistsException;
+import com.devops.authservice.model.ErrorResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleEmailConflict_returns409WithCode() {
+        ResponseEntity<ErrorResponse> result =
+                handler.handleEmailConflict(new EmailAlreadyExistsException("user@example.com"));
+
+        assertThat(result.getStatusCode().value()).isEqualTo(409);
+        assertThat(result.getBody().getCode()).isEqualTo("EMAIL_ALREADY_EXISTS");
+        assertThat(result.getBody().getMessage()).contains("user@example.com");
+    }
+
+    @Test
+    void handleUsernameConflict_returns409WithCode() {
+        ResponseEntity<ErrorResponse> result =
+                handler.handleUsernameConflict(new UsernameAlreadyExistsException("alice"));
+
+        assertThat(result.getStatusCode().value()).isEqualTo(409);
+        assertThat(result.getBody().getCode()).isEqualTo("USERNAME_ALREADY_EXISTS");
+    }
+
+    @Test
+    void handleValidation_returns422WithFirstFieldError() {
+        BeanPropertyBindingResult binding = new BeanPropertyBindingResult(new Object(), "registerRequest");
+        binding.addError(new FieldError("registerRequest", "email", "must not be blank"));
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+        when(ex.getBindingResult()).thenReturn(binding);
+
+        ResponseEntity<ErrorResponse> result = handler.handleValidation(ex);
+
+        assertThat(result.getStatusCode().value()).isEqualTo(422);
+        assertThat(result.getBody().getCode()).isEqualTo("VALIDATION_ERROR");
+        assertThat(result.getBody().getMessage()).isEqualTo("email: must not be blank");
+    }
+}

--- a/services/auth-service/tests/java/com/devops/authservice/controller/session/RefreshControllerTest.java
+++ b/services/auth-service/tests/java/com/devops/authservice/controller/session/RefreshControllerTest.java
@@ -1,0 +1,121 @@
+package com.devops.authservice.controller.session;
+
+import com.devops.authservice.entity.SessionEntity;
+import com.devops.authservice.entity.UserEntity;
+import com.devops.authservice.repository.UserRepository;
+import com.devops.authservice.service.SessionService;
+import com.devops.authservice.service.TokenCookieService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshControllerTest {
+
+    @Mock
+    private SessionService sessionService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private TokenCookieService tokenCookieService;
+
+    private RefreshController controller;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        controller = new RefreshController(sessionService, userRepository, tokenCookieService);
+    }
+
+    @Test
+    void refresh_issuesNewAccessToken_whenSessionAndUserValid() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        SessionEntity session = mock(SessionEntity.class);
+        when(session.getUserId()).thenReturn(userId);
+        when(sessionService.validate(sessionId)).thenReturn(Optional.of(session));
+
+        UserEntity user = mock(UserEntity.class);
+        when(user.getId()).thenReturn(userId);
+        when(user.getEmail()).thenReturn("user@example.com");
+        when(user.getUsername()).thenReturn("alice");
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("session_id", sessionId.toString()));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ResponseEntity<Void> result = controller.refresh(request, response);
+
+        assertThat(result.getStatusCode().value()).isEqualTo(200);
+        verify(tokenCookieService).issueAccessToken(eq(userId), eq("user@example.com"), eq("alice"),
+                eq(response));
+    }
+
+    @Test
+    void refresh_returns401_whenNoSessionCookie() {
+        ResponseEntity<Void> result =
+                controller.refresh(new MockHttpServletRequest(), new MockHttpServletResponse());
+
+        assertThat(result.getStatusCode().value()).isEqualTo(401);
+        verify(tokenCookieService, never()).issueAccessToken(any(), any(), any(), any());
+    }
+
+    @Test
+    void refresh_returns401_whenSessionCookieIsNotAUuid() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("session_id", "not-a-uuid"));
+
+        ResponseEntity<Void> result = controller.refresh(request, new MockHttpServletResponse());
+
+        assertThat(result.getStatusCode().value()).isEqualTo(401);
+        verify(sessionService, never()).validate(any());
+    }
+
+    @Test
+    void refresh_returns401_whenSessionInvalid() {
+        UUID sessionId = UUID.randomUUID();
+        when(sessionService.validate(sessionId)).thenReturn(Optional.empty());
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("session_id", sessionId.toString()));
+
+        ResponseEntity<Void> result = controller.refresh(request, new MockHttpServletResponse());
+
+        assertThat(result.getStatusCode().value()).isEqualTo(401);
+        verify(tokenCookieService, never()).issueAccessToken(any(), any(), any(), any());
+    }
+
+    @Test
+    void refresh_returns401_whenUserMissing() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        SessionEntity session = mock(SessionEntity.class);
+        when(session.getUserId()).thenReturn(userId);
+        when(sessionService.validate(sessionId)).thenReturn(Optional.of(session));
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("session_id", sessionId.toString()));
+
+        ResponseEntity<Void> result = controller.refresh(request, new MockHttpServletResponse());
+
+        assertThat(result.getStatusCode().value()).isEqualTo(401);
+        verify(tokenCookieService, never()).issueAccessToken(any(), any(), any(), any());
+    }
+}

--- a/services/auth-service/tests/java/com/devops/authservice/controller/session/SessionControllerTest.java
+++ b/services/auth-service/tests/java/com/devops/authservice/controller/session/SessionControllerTest.java
@@ -1,0 +1,95 @@
+package com.devops.authservice.controller.session;
+
+import com.devops.authservice.service.JwtService;
+import com.devops.authservice.service.SessionService;
+import com.devops.authservice.service.TokenCookieService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class SessionControllerTest {
+
+    private final JwtService jwtService =
+            new JwtService("test-secret-key-that-is-at-least-32-bytes!!", 900_000L);
+
+    @Mock
+    private SessionService sessionService;
+    @Mock
+    private TokenCookieService tokenCookieService;
+
+    private SessionController controller;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        controller = new SessionController(jwtService, sessionService, tokenCookieService);
+    }
+
+    @Test
+    void me_returnsClaims_whenAccessTokenValid() {
+        UUID userId = UUID.randomUUID();
+        String token = jwtService.generate(userId, "user@example.com", "alice");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("access_token", token));
+
+        ResponseEntity<Map<String, Object>> result = controller.me(request);
+
+        assertThat(result.getStatusCode().value()).isEqualTo(200);
+        assertThat(result.getBody()).containsEntry("id", userId.toString())
+                .containsEntry("email", "user@example.com")
+                .containsEntry("username", "alice");
+    }
+
+    @Test
+    void me_returns401_whenNoCookiePresent() {
+        ResponseEntity<Map<String, Object>> result = controller.me(new MockHttpServletRequest());
+        assertThat(result.getStatusCode().value()).isEqualTo(401);
+    }
+
+    @Test
+    void me_returns401_whenTokenInvalid() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("access_token", "garbage.token.value"));
+
+        ResponseEntity<Map<String, Object>> result = controller.me(request);
+
+        assertThat(result.getStatusCode().value()).isEqualTo(401);
+    }
+
+    @Test
+    void logout_revokesSession_clearsCookies_andReturns204() {
+        UUID sessionId = UUID.randomUUID();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("session_id", sessionId.toString()));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ResponseEntity<Void> result = controller.logout(request, response);
+
+        assertThat(result.getStatusCode().value()).isEqualTo(204);
+        verify(sessionService).revoke(sessionId);
+        verify(tokenCookieService).clearAll(response);
+    }
+
+    @Test
+    void logout_stillClearsCookies_whenNoSessionCookie() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ResponseEntity<Void> result = controller.logout(new MockHttpServletRequest(), response);
+
+        assertThat(result.getStatusCode().value()).isEqualTo(204);
+        verifyNoInteractions(sessionService);
+        verify(tokenCookieService).clearAll(response);
+    }
+}

--- a/services/auth-service/tests/java/com/devops/authservice/controller/user/login/LoginControllerTest.java
+++ b/services/auth-service/tests/java/com/devops/authservice/controller/user/login/LoginControllerTest.java
@@ -1,0 +1,113 @@
+package com.devops.authservice.controller.user.login;
+
+import com.devops.authservice.entity.SessionEntity;
+import com.devops.authservice.entity.UserEntity;
+import com.devops.authservice.repository.UserRepository;
+import com.devops.authservice.service.SessionService;
+import com.devops.authservice.service.TokenCookieService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LoginControllerTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private SessionService sessionService;
+    @Mock
+    private TokenCookieService tokenCookieService;
+
+    private LoginController controller;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        controller = new LoginController(userRepository, sessionService, tokenCookieService);
+    }
+
+    @Test
+    void login_succeeds_withCorrectCredentials_andIssuesCookies() {
+        UUID userId = UUID.randomUUID();
+        String hash = new BCryptPasswordEncoder().encode("correct-password");
+        UserEntity user = mock(UserEntity.class);
+        when(user.getId()).thenReturn(userId);
+        when(user.getEmail()).thenReturn("user@example.com");
+        when(user.getUsername()).thenReturn("alice");
+        when(user.getPasswordHash()).thenReturn(hash);
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+        SessionEntity session = mock(SessionEntity.class);
+        when(sessionService.create(userId)).thenReturn(session);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        ResponseEntity<Map<String, Object>> result = controller.login(
+                new LoginController.LoginRequest("user@example.com", "correct-password"), response);
+
+        assertThat(result.getStatusCode().value()).isEqualTo(200);
+        assertThat(result.getBody()).containsEntry("email", "user@example.com")
+                .containsEntry("username", "alice")
+                .containsEntry("id", userId.toString());
+        verify(tokenCookieService).issue(eq(userId), eq("user@example.com"), eq("alice"),
+                eq(session), any(MockHttpServletResponse.class));
+    }
+
+    @Test
+    void login_returns401_whenUserNotFound() {
+        when(userRepository.findByEmail("missing@example.com")).thenReturn(Optional.empty());
+
+        ResponseEntity<Map<String, Object>> result = controller.login(
+                new LoginController.LoginRequest("missing@example.com", "whatever"),
+                new MockHttpServletResponse());
+
+        assertThat(result.getStatusCode().value()).isEqualTo(401);
+        assertThat(result.getBody()).containsEntry("code", "INVALID_CREDENTIALS");
+        verify(sessionService, never()).create(any());
+        verify(tokenCookieService, never()).issue(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void login_returns401_whenPasswordDoesNotMatch() {
+        String hash = new BCryptPasswordEncoder().encode("the-real-password");
+        UserEntity user = mock(UserEntity.class);
+        when(user.getPasswordHash()).thenReturn(hash);
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        ResponseEntity<Map<String, Object>> result = controller.login(
+                new LoginController.LoginRequest("user@example.com", "wrong-password"),
+                new MockHttpServletResponse());
+
+        assertThat(result.getStatusCode().value()).isEqualTo(401);
+        assertThat(result.getBody()).containsEntry("code", "INVALID_CREDENTIALS");
+        verify(tokenCookieService, never()).issue(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void login_returns401_whenAccountHasNoPassword() {
+        UserEntity user = mock(UserEntity.class);
+        when(user.getPasswordHash()).thenReturn(null);
+        when(userRepository.findByEmail("oauth@example.com")).thenReturn(Optional.of(user));
+
+        ResponseEntity<Map<String, Object>> result = controller.login(
+                new LoginController.LoginRequest("oauth@example.com", "anything"),
+                new MockHttpServletResponse());
+
+        assertThat(result.getStatusCode().value()).isEqualTo(401);
+        verify(tokenCookieService, never()).issue(any(), any(), any(), any(), any());
+    }
+}

--- a/services/auth-service/tests/java/com/devops/authservice/domain/user/register/RegisterInteractorTest.java
+++ b/services/auth-service/tests/java/com/devops/authservice/domain/user/register/RegisterInteractorTest.java
@@ -1,0 +1,88 @@
+package com.devops.authservice.domain.user.register;
+
+import com.devops.authservice.domain.user.exception.EmailAlreadyExistsException;
+import com.devops.authservice.domain.user.exception.UsernameAlreadyExistsException;
+import com.devops.authservice.entity.UserEntity;
+import com.devops.authservice.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterInteractorTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    private RegisterInteractor interactor;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        interactor = new RegisterInteractor(userRepository);
+    }
+
+    @Test
+    void execute_persistsUserWithHashedPassword_andReturnsOutput() {
+        UUID id = UUID.randomUUID();
+        when(userRepository.existsByEmail("user@example.com")).thenReturn(false);
+        when(userRepository.existsByUsername("alice")).thenReturn(false);
+
+        UserEntity saved = mock(UserEntity.class);
+        when(saved.getId()).thenReturn(id);
+        when(saved.getEmail()).thenReturn("user@example.com");
+        when(saved.getUsername()).thenReturn("alice");
+        when(userRepository.save(any(UserEntity.class))).thenReturn(saved);
+
+        RegisterOutput output = interactor.execute(
+                new RegisterInput("user@example.com", "s3cret-password", "alice"));
+
+        assertThat(output.id()).isEqualTo(id);
+        assertThat(output.email()).isEqualTo("user@example.com");
+        assertThat(output.username()).isEqualTo("alice");
+
+        ArgumentCaptor<UserEntity> captor = ArgumentCaptor.forClass(UserEntity.class);
+        verify(userRepository).save(captor.capture());
+        UserEntity persisted = captor.getValue();
+        assertThat(persisted.getEmail()).isEqualTo("user@example.com");
+        assertThat(persisted.getUsername()).isEqualTo("alice");
+        assertThat(persisted.getPasswordHash()).isNotEqualTo("s3cret-password");
+        assertThat(new BCryptPasswordEncoder().matches("s3cret-password", persisted.getPasswordHash()))
+                .isTrue();
+    }
+
+    @Test
+    void execute_throwsWhenEmailAlreadyExists() {
+        when(userRepository.existsByEmail("user@example.com")).thenReturn(true);
+
+        assertThatThrownBy(() -> interactor.execute(
+                new RegisterInput("user@example.com", "pw", "alice")))
+                .isInstanceOf(EmailAlreadyExistsException.class);
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void execute_throwsWhenUsernameAlreadyExists() {
+        when(userRepository.existsByEmail("user@example.com")).thenReturn(false);
+        when(userRepository.existsByUsername("alice")).thenReturn(true);
+
+        assertThatThrownBy(() -> interactor.execute(
+                new RegisterInput("user@example.com", "pw", "alice")))
+                .isInstanceOf(UsernameAlreadyExistsException.class);
+
+        verify(userRepository, never()).save(any());
+    }
+}

--- a/services/auth-service/tests/java/com/devops/authservice/service/JwtServiceTest.java
+++ b/services/auth-service/tests/java/com/devops/authservice/service/JwtServiceTest.java
@@ -1,0 +1,67 @@
+package com.devops.authservice.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtServiceTest {
+
+    private static final String SECRET = "test-secret-key-that-is-at-least-32-bytes!!";
+    private static final long EXPIRATION_MS = 900_000L;
+
+    private final JwtService jwtService = new JwtService(SECRET, EXPIRATION_MS);
+
+    @Test
+    void generateThenParse_roundTripsAllClaims() {
+        UUID userId = UUID.randomUUID();
+
+        String token = jwtService.generate(userId, "user@example.com", "alice");
+        Claims claims = jwtService.getClaims(token);
+
+        assertThat(claims.getSubject()).isEqualTo(userId.toString());
+        assertThat(claims.get("email", String.class)).isEqualTo("user@example.com");
+        assertThat(claims.get("username", String.class)).isEqualTo("alice");
+    }
+
+    @Test
+    void generatedToken_hasExpiryInTheFuture() {
+        String token = jwtService.generate(UUID.randomUUID(), "user@example.com", "alice");
+        Claims claims = jwtService.getClaims(token);
+
+        assertThat(claims.getExpiration()).isAfter(claims.getIssuedAt());
+    }
+
+    @Test
+    void getExpirationMs_returnsConfiguredValue() {
+        assertThat(jwtService.getExpirationMs()).isEqualTo(EXPIRATION_MS);
+    }
+
+    @Test
+    void getClaims_rejectsGarbageToken() {
+        assertThatThrownBy(() -> jwtService.getClaims("not-a-jwt"))
+                .isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    void getClaims_rejectsTokenSignedWithDifferentKey() {
+        JwtService otherIssuer = new JwtService("a-completely-different-secret-key-32b!!!", EXPIRATION_MS);
+        String foreignToken = otherIssuer.generate(UUID.randomUUID(), "e@x.com", "bob");
+
+        assertThatThrownBy(() -> jwtService.getClaims(foreignToken))
+                .isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    void getClaims_rejectsExpiredToken() {
+        JwtService shortLived = new JwtService(SECRET, -1_000L);
+        String expired = shortLived.generate(UUID.randomUUID(), "e@x.com", "bob");
+
+        assertThatThrownBy(() -> jwtService.getClaims(expired))
+                .isInstanceOf(JwtException.class);
+    }
+}

--- a/services/auth-service/tests/java/com/devops/authservice/service/SessionServiceTest.java
+++ b/services/auth-service/tests/java/com/devops/authservice/service/SessionServiceTest.java
@@ -1,0 +1,126 @@
+package com.devops.authservice.service;
+
+import com.devops.authservice.entity.SessionEntity;
+import com.devops.authservice.entity.SessionStatus;
+import com.devops.authservice.repository.SessionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SessionServiceTest {
+
+    private static final long EXPIRATION_MS = 86_400_000L;
+
+    @Mock
+    private SessionRepository sessionRepository;
+
+    private SessionService sessionService;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        sessionService = new SessionService(sessionRepository, EXPIRATION_MS);
+    }
+
+    @Test
+    void create_persistsActiveSessionWithFutureExpiry() {
+        UUID userId = UUID.randomUUID();
+        when(sessionRepository.save(any(SessionEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        SessionEntity created = sessionService.create(userId);
+
+        ArgumentCaptor<SessionEntity> captor = ArgumentCaptor.forClass(SessionEntity.class);
+        verify(sessionRepository).save(captor.capture());
+        SessionEntity saved = captor.getValue();
+
+        assertThat(created).isSameAs(saved);
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getUserId()).isEqualTo(userId);
+        assertThat(saved.getStatus()).isEqualTo(SessionStatus.ACTIVE);
+        assertThat(saved.getExpiresAt()).isAfter(LocalDateTime.now());
+        assertThat(saved.getExpiresAt()).isAfter(saved.getCreatedAt());
+    }
+
+    @Test
+    void validate_returnsSessionAndBumpsLastUsed_whenActiveAndNotExpired() {
+        UUID sessionId = UUID.randomUUID();
+        SessionEntity session = activeSession(sessionId, LocalDateTime.now().plusHours(1));
+        when(sessionRepository.findByIdAndStatus(sessionId, SessionStatus.ACTIVE))
+                .thenReturn(Optional.of(session));
+        when(sessionRepository.save(any(SessionEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Optional<SessionEntity> result = sessionService.validate(sessionId);
+
+        assertThat(result).isPresent();
+        verify(sessionRepository).save(session);
+    }
+
+    @Test
+    void validate_returnsEmpty_whenSessionExpired() {
+        UUID sessionId = UUID.randomUUID();
+        SessionEntity expired = activeSession(sessionId, LocalDateTime.now().minusMinutes(1));
+        when(sessionRepository.findByIdAndStatus(sessionId, SessionStatus.ACTIVE))
+                .thenReturn(Optional.of(expired));
+
+        Optional<SessionEntity> result = sessionService.validate(sessionId);
+
+        assertThat(result).isEmpty();
+        verify(sessionRepository, never()).save(any());
+    }
+
+    @Test
+    void validate_returnsEmpty_whenNoActiveSessionFound() {
+        UUID sessionId = UUID.randomUUID();
+        when(sessionRepository.findByIdAndStatus(sessionId, SessionStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        assertThat(sessionService.validate(sessionId)).isEmpty();
+        verify(sessionRepository, never()).save(any());
+    }
+
+    @Test
+    void revoke_marksSessionRevoked_whenPresent() {
+        UUID sessionId = UUID.randomUUID();
+        SessionEntity session = activeSession(sessionId, LocalDateTime.now().plusHours(1));
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+
+        sessionService.revoke(sessionId);
+
+        assertThat(session.getStatus()).isEqualTo(SessionStatus.REVOKED);
+        verify(sessionRepository).save(session);
+    }
+
+    @Test
+    void revoke_isNoOp_whenSessionMissing() {
+        UUID sessionId = UUID.randomUUID();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.empty());
+
+        sessionService.revoke(sessionId);
+
+        verify(sessionRepository, never()).save(any());
+    }
+
+    private SessionEntity activeSession(UUID id, LocalDateTime expiresAt) {
+        SessionEntity session = new SessionEntity();
+        session.setId(id);
+        session.setUserId(UUID.randomUUID());
+        session.setStatus(SessionStatus.ACTIVE);
+        session.setCreatedAt(LocalDateTime.now().minusMinutes(5));
+        session.setLastUsedAt(LocalDateTime.now().minusMinutes(5));
+        session.setExpiresAt(expiresAt);
+        return session;
+    }
+}

--- a/services/auth-service/tests/java/com/devops/authservice/service/TokenCookieServiceTest.java
+++ b/services/auth-service/tests/java/com/devops/authservice/service/TokenCookieServiceTest.java
@@ -1,0 +1,67 @@
+package com.devops.authservice.service;
+
+import com.devops.authservice.entity.SessionEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenCookieServiceTest {
+
+    private final JwtService jwtService =
+            new JwtService("test-secret-key-that-is-at-least-32-bytes!!", 900_000L);
+    private final TokenCookieService service = new TokenCookieService(jwtService);
+
+    @Test
+    void issue_setsHttpOnlySecureSessionAndAccessCookies() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        SessionEntity session = new SessionEntity();
+        session.setId(UUID.randomUUID());
+        session.setExpiresAt(LocalDateTime.now().plusDays(1));
+
+        service.issue(UUID.randomUUID(), "user@example.com", "alice", session, response);
+
+        List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(2);
+        assertThat(cookies).anySatisfy(c -> assertThat(c)
+                .startsWith("session_id=" + session.getId())
+                .contains("HttpOnly").contains("Secure").contains("SameSite=Lax"));
+        assertThat(cookies).anySatisfy(c -> assertThat(c)
+                .startsWith("access_token=")
+                .contains("HttpOnly").contains("Secure").contains("SameSite=Lax"));
+    }
+
+    @Test
+    void issueAccessToken_setsOnlyAccessCookieWithValidJwt() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        UUID userId = UUID.randomUUID();
+
+        service.issueAccessToken(userId, "user@example.com", "alice", response);
+
+        List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(1);
+        String accessCookie = cookies.get(0);
+        assertThat(accessCookie).startsWith("access_token=");
+
+        String jwt = accessCookie.substring("access_token=".length(), accessCookie.indexOf(';'));
+        assertThat(jwtService.getClaims(jwt).getSubject()).isEqualTo(userId.toString());
+    }
+
+    @Test
+    void clearAll_expiresBothCookies() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        service.clearAll(response);
+
+        List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(2);
+        assertThat(cookies).allSatisfy(c -> assertThat(c).contains("Max-Age=0"));
+        assertThat(cookies).anySatisfy(c -> assertThat(c).startsWith("session_id="));
+        assertThat(cookies).anySatisfy(c -> assertThat(c).startsWith("access_token="));
+    }
+}


### PR DESCRIPTION
Add unit tests covering the auth-service (JWT, sessions, token cookies, registration, login/refresh/session controllers, error handling) and the api-gateway JWT auth filter. Tests live in a top-level tests/ directory wired via build-helper-maven-plugin.

Add a Tests GitHub Actions workflow that runs both suites on PRs to main so the checks can gate merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for authentication, login, registration, sessions, token handling, cookies, validation errors, and gateway authorization.
  * Added checks for successful requests, invalid credentials, expired or malformed tokens, unauthorized sessions, and expected response codes.
* **Chores**
  * Configured Maven to include additional test sources.
  * Added automated test execution for authentication and gateway services, with test reports uploaded for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->