### PR TITLE
feat: add integration + acceptance test suites and coverage across se…

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
         service:
           - auth-service
           - api-gateway
+          - flashcard-service
           - study-service
     steps:
       - name: Checkout

--- a/.github/workflows/test_python_services.yaml
+++ b/.github/workflows/test_python_services.yaml
@@ -86,7 +86,7 @@ jobs:
         run: |
           pip install --no-cache-dir -r requirements.txt
           pip install --no-cache-dir -e .
-          pip install --no-cache-dir pytest
+          pip install --no-cache-dir pytest pytest-cov
 
       - name: Run pytest
-        run: pytest tests
+        run: pytest --cov=src/openapi_server --cov-report=term-missing --cov-report=xml tests

--- a/services/api-gateway/pom.xml
+++ b/services/api-gateway/pom.xml
@@ -72,6 +72,17 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.9.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -91,6 +102,26 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/services/api-gateway/tests/java/com/devops/apigateway/GatewayRoutingAcceptanceTest.java
+++ b/services/api-gateway/tests/java/com/devops/apigateway/GatewayRoutingAcceptanceTest.java
@@ -1,0 +1,140 @@
+package com.devops.apigateway;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+/**
+ * Acceptance tests for the gateway: start it for real and route to a WireMock
+ * stub standing in for every downstream service. Verifies routing, edge
+ * authentication (reject / forward), identity-header injection, public-path
+ * bypass, and the transparent access-token refresh via the session cookie.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class GatewayRoutingAcceptanceTest {
+
+    private static final String SECRET = "gateway-acceptance-secret-at-least-32-bytes!!";
+    private static final SecretKey KEY = Keys.hmacShaKeyFor(SECRET.getBytes());
+
+    private static final WireMockServer BACKEND = new WireMockServer(options().dynamicPort());
+
+    @LocalServerPort
+    private int port;
+
+    private WebTestClient client;
+
+    @BeforeAll
+    static void startBackend() {
+        BACKEND.start();
+    }
+
+    @AfterAll
+    static void stopBackend() {
+        BACKEND.stop();
+    }
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        String base = "http://localhost:" + BACKEND.port();
+        registry.add("JWT_SECRET", () -> SECRET);
+        registry.add("AUTH_SERVICE_URL", () -> base);
+        registry.add("FLASHCARD_SERVICE_URL", () -> base);
+        registry.add("GENAI_SERVICE_URL", () -> base);
+        registry.add("UPLOAD_SERVICE_URL", () -> base);
+    }
+
+    @BeforeEach
+    void setUp() {
+        client = WebTestClient.bindToServer().baseUrl("http://localhost:" + port).build();
+        BACKEND.resetAll();
+        // Default: any downstream call succeeds.
+        BACKEND.stubFor(any(anyUrl()).atPriority(10)
+                .willReturn(aResponse().withStatus(200).withBody("downstream-ok")));
+    }
+
+    private String token(UUID userId, long ttlMillis) {
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("email", "user@example.com")
+                .claim("username", "alice")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + ttlMillis))
+                .signWith(KEY)
+                .compact();
+    }
+
+    @Test
+    void protectedRouteWithoutCookieIsRejected() {
+        client.get().uri("/api/v1/flashcards").exchange()
+                .expectStatus().isUnauthorized();
+
+        BACKEND.verify(0, getRequestedFor(urlEqualTo("/api/v1/flashcards")));
+    }
+
+    @Test
+    void validTokenIsForwardedWithUserHeaders() {
+        UUID userId = UUID.randomUUID();
+
+        client.get().uri("/api/v1/flashcards")
+                .cookie("access_token", token(userId, 900_000L))
+                .exchange()
+                .expectStatus().isOk();
+
+        BACKEND.verify(getRequestedFor(urlEqualTo("/api/v1/flashcards"))
+                .withHeader("X-User-Id", equalTo(userId.toString())));
+    }
+
+    @Test
+    void publicAuthRouteIsForwardedWithoutAuthentication() {
+        client.post().uri("/api/v1/auth/login")
+                .bodyValue("{}")
+                .exchange()
+                .expectStatus().isOk();
+
+        BACKEND.verify(postRequestedFor(urlEqualTo("/api/v1/auth/login")));
+    }
+
+    @Test
+    void expiredTokenIsRefreshedViaSessionThenForwarded() {
+        UUID userId = UUID.randomUUID();
+        String freshToken = token(userId, 900_000L);
+
+        // Auth service issues a fresh access token cookie on refresh.
+        BACKEND.stubFor(post(urlEqualTo("/api/v1/auth/refresh")).atPriority(1)
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Set-Cookie", "access_token=" + freshToken + "; Path=/; HttpOnly")));
+
+        client.get().uri("/api/v1/flashcards")
+                .cookie("access_token", token(userId, -1_000L)) // already expired
+                .cookie("session_id", UUID.randomUUID().toString())
+                .exchange()
+                .expectStatus().isOk();
+
+        BACKEND.verify(postRequestedFor(urlEqualTo("/api/v1/auth/refresh")));
+        BACKEND.verify(getRequestedFor(urlEqualTo("/api/v1/flashcards"))
+                .withHeader("X-User-Id", equalTo(userId.toString())));
+    }
+}

--- a/services/auth-service/pom.xml
+++ b/services/auth-service/pom.xml
@@ -23,6 +23,20 @@
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Newer Testcontainers/docker-java: the version managed by Spring Boot
+                 3.3 negotiates Docker API 1.32, which modern engines (OrbStack) reject. -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.20.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -112,6 +126,21 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -119,6 +148,37 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Pin Docker API version for Testcontainers; the default 1.32
+                         is rejected by engines with min API 1.40 (e.g. OrbStack). -->
+                    <systemPropertyVariables>
+                        <api.version>1.41</api.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/services/auth-service/tests/java/com/devops/authservice/acceptance/AuthAcceptanceTest.java
+++ b/services/auth-service/tests/java/com/devops/authservice/acceptance/AuthAcceptanceTest.java
@@ -1,0 +1,167 @@
+package com.devops.authservice.acceptance;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Acceptance tests driving the auth service over HTTP against a real PostgreSQL.
+ * Exercises the end-to-end authentication flows exactly as a client would:
+ * registration, session cookies, /me, token refresh, login, and logout.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class AuthAcceptanceTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    private static final String PASSWORD = "Password123!";
+
+    private String uniqueEmail() {
+        return "user-" + UUID.randomUUID() + "@test.local";
+    }
+
+    private ResponseEntity<String> register(String email, String username) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String body = "{\"email\":\"%s\",\"username\":\"%s\",\"password\":\"%s\"}"
+                .formatted(email, username, PASSWORD);
+        return rest.exchange("/api/v1/auth/register", HttpMethod.POST,
+                new HttpEntity<>(body, headers), String.class);
+    }
+
+    private Map<String, String> cookiesFrom(ResponseEntity<?> response) {
+        Map<String, String> jar = new HashMap<>();
+        List<String> setCookies = response.getHeaders().get(HttpHeaders.SET_COOKIE);
+        if (setCookies != null) {
+            for (String setCookie : setCookies) {
+                String pair = setCookie.split(";", 2)[0];
+                int eq = pair.indexOf('=');
+                if (eq > 0) {
+                    jar.put(pair.substring(0, eq), pair.substring(eq + 1));
+                }
+            }
+        }
+        return jar;
+    }
+
+    private HttpHeaders withCookies(Map<String, String> jar) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String cookie = jar.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining("; "));
+        if (!cookie.isBlank()) {
+            headers.add(HttpHeaders.COOKIE, cookie);
+        }
+        return headers;
+    }
+
+    @Test
+    void registerIssuesSessionCookiesAndMeReturnsUser() {
+        String email = uniqueEmail();
+        ResponseEntity<String> registered = register(email, "user" + System.nanoTime());
+
+        assertThat(registered.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        Map<String, String> jar = cookiesFrom(registered);
+        assertThat(jar).containsKeys("access_token", "session_id");
+
+        ResponseEntity<String> me = rest.exchange("/api/v1/auth/me", HttpMethod.GET,
+                new HttpEntity<>(withCookies(jar)), String.class);
+        assertThat(me.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(me.getBody()).contains(email);
+    }
+
+    @Test
+    void meWithoutCookieIsUnauthorized() {
+        ResponseEntity<String> me = rest.getForEntity("/api/v1/auth/me", String.class);
+        assertThat(me.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void refreshRotatesAccessTokenFromSession() {
+        Map<String, String> jar = cookiesFrom(register(uniqueEmail(), "user" + System.nanoTime()));
+
+        ResponseEntity<String> refreshed = rest.exchange("/api/v1/auth/refresh", HttpMethod.POST,
+                new HttpEntity<>(withCookies(jar)), String.class);
+
+        assertThat(refreshed.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(cookiesFrom(refreshed)).containsKey("access_token");
+    }
+
+    @Test
+    void loginWithWrongPasswordIsUnauthorized() {
+        String email = uniqueEmail();
+        register(email, "user" + System.nanoTime());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<String> login = rest.exchange("/api/v1/auth/login", HttpMethod.POST,
+                new HttpEntity<>("{\"email\":\"" + email + "\",\"password\":\"wrong\"}", headers), String.class);
+
+        assertThat(login.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void loginWithValidCredentialsSucceeds() {
+        String email = uniqueEmail();
+        register(email, "user" + System.nanoTime());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<String> login = rest.exchange("/api/v1/auth/login", HttpMethod.POST,
+                new HttpEntity<>("{\"email\":\"" + email + "\",\"password\":\"" + PASSWORD + "\"}", headers),
+                String.class);
+
+        assertThat(login.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(cookiesFrom(login)).containsKeys("access_token", "session_id");
+        assertThat(login.getBody()).contains(email);
+    }
+
+    @Test
+    void logoutRevokesSessionSoRefreshFails() {
+        Map<String, String> jar = cookiesFrom(register(uniqueEmail(), "user" + System.nanoTime()));
+
+        ResponseEntity<Void> logout = rest.exchange("/api/v1/auth/logout", HttpMethod.POST,
+                new HttpEntity<>(withCookies(jar)), Void.class);
+        assertThat(logout.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        // The session is revoked, so a refresh with the same session_id is rejected.
+        ResponseEntity<String> refresh = rest.exchange("/api/v1/auth/refresh", HttpMethod.POST,
+                new HttpEntity<>(withCookies(jar)), String.class);
+        assertThat(refresh.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void duplicateEmailIsRejected() {
+        String email = uniqueEmail();
+        assertThat(register(email, "user" + System.nanoTime()).getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        ResponseEntity<String> duplicate = register(email, "user" + System.nanoTime());
+        assertThat(duplicate.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    }
+}

--- a/services/auth-service/tests/java/com/devops/authservice/integration/AuthPersistenceIntegrationTest.java
+++ b/services/auth-service/tests/java/com/devops/authservice/integration/AuthPersistenceIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.devops.authservice.integration;
+
+import com.devops.authservice.entity.SessionEntity;
+import com.devops.authservice.entity.SessionStatus;
+import com.devops.authservice.entity.UserEntity;
+import com.devops.authservice.repository.SessionRepository;
+import com.devops.authservice.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the auth persistence layer against a real PostgreSQL
+ * (Testcontainers), exercising the Liquibase-migrated schema and the derived
+ * repository queries used for authentication and session management.
+ */
+@SpringBootTest
+@Testcontainers
+class AuthPersistenceIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    private UserEntity newUser(String email, String username) {
+        UserEntity user = new UserEntity();
+        user.setEmail(email);
+        user.setUsername(username);
+        user.setPasswordHash("$2a$10$hashplaceholderhashplaceholderhashplaceholder");
+        return user;
+    }
+
+    @Test
+    void userUniquenessAndLookups() {
+        UserEntity saved = userRepository.save(newUser("a@test.local", "alice"));
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(userRepository.existsByEmail("a@test.local")).isTrue();
+        assertThat(userRepository.existsByUsername("alice")).isTrue();
+        assertThat(userRepository.existsByEmail("missing@test.local")).isFalse();
+        assertThat(userRepository.findByEmail("a@test.local")).isPresent();
+        assertThat(userRepository.findByEmail("a@test.local").get().getId()).isEqualTo(saved.getId());
+    }
+
+    @Test
+    void findByGoogleId() {
+        UserEntity user = newUser("g@test.local", "googler");
+        user.setPasswordHash(null);
+        user.setGoogleId("google-123");
+        userRepository.save(user);
+
+        assertThat(userRepository.findByGoogleId("google-123")).isPresent();
+        assertThat(userRepository.findByGoogleId("nope")).isEmpty();
+    }
+
+    @Test
+    void sessionLookupIsScopedByStatus() {
+        UserEntity user = userRepository.save(newUser("s@test.local", "sam"));
+
+        SessionEntity session = new SessionEntity();
+        session.setId(UUID.randomUUID());
+        session.setUserId(user.getId());
+        session.setStatus(SessionStatus.ACTIVE);
+        session.setCreatedAt(LocalDateTime.now());
+        session.setExpiresAt(LocalDateTime.now().plusDays(1));
+        session.setLastUsedAt(LocalDateTime.now());
+        sessionRepository.save(session);
+
+        assertThat(sessionRepository.findByIdAndStatus(session.getId(), SessionStatus.ACTIVE)).isPresent();
+        assertThat(sessionRepository.findByIdAndStatus(session.getId(), SessionStatus.REVOKED)).isEmpty();
+
+        session.setStatus(SessionStatus.REVOKED);
+        sessionRepository.save(session);
+        assertThat(sessionRepository.findByIdAndStatus(session.getId(), SessionStatus.ACTIVE)).isEmpty();
+    }
+}

--- a/services/flashcard-service/pom.xml
+++ b/services/flashcard-service/pom.xml
@@ -23,6 +23,23 @@
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!--
+              Use a newer Testcontainers (and its docker-java client) than the one
+              managed by Spring Boot 3.3. The older client negotiates Docker API
+              1.32, which modern engines such as OrbStack reject (require >= 1.40).
+            -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.20.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -108,6 +125,21 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -115,6 +147,41 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--
+                      Pin the Docker Engine API version used by Testcontainers'
+                      Docker client. It otherwise defaults to 1.32, which modern
+                      engines (e.g. OrbStack, min API 1.40) reject. 1.41 is
+                      supported by Docker 20.10+ and by CI's Docker.
+                    -->
+                    <systemPropertyVariables>
+                        <api.version>1.41</api.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.openapitools</groupId>

--- a/services/flashcard-service/src/test/java/com/devops/springservice/flashcard/FlashcardAcceptanceTest.java
+++ b/services/flashcard-service/src/test/java/com/devops/springservice/flashcard/FlashcardAcceptanceTest.java
@@ -1,0 +1,127 @@
+package com.devops.springservice.flashcard;
+
+import com.devops.springservice.model.Flashcard;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Acceptance tests: drive the running service over HTTP (random port) against a
+ * real PostgreSQL, authenticating with a signed JWT cookie exactly like the
+ * gateway would. Exercises the full create → read → update → batch → delete
+ * lifecycle end-to-end, plus authentication and per-user isolation.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class FlashcardAcceptanceTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @Autowired
+    private FlashcardRepository repository;
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    private final UUID userA = UUID.randomUUID();
+    private final UUID userB = UUID.randomUUID();
+
+    @BeforeEach
+    void reset() {
+        repository.deleteAll();
+    }
+
+    private HttpHeaders authFor(UUID userId) {
+        String token = Jwts.builder()
+                .subject(userId.toString())
+                .signWith(Keys.hmacShaKeyFor(jwtSecret.getBytes()))
+                .compact();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.COOKIE, "access_token=" + token);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+
+    @Test
+    void unauthenticatedRequestIsRejected() {
+        ResponseEntity<String> response = rest.getForEntity("/api/v1/flashcards", String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void fullLifecycleWithUserIsolation() {
+        String createBody = """
+                {"question":"What is a hypervisor?","answer":"Runs VMs.",
+                 "source_ref":"upload-1","source_name":"lecture.pdf"}""";
+
+        // Create as user A
+        ResponseEntity<Flashcard> created = rest.exchange(
+                "/api/v1/flashcards", HttpMethod.POST,
+                new HttpEntity<>(createBody, authFor(userA)), Flashcard.class);
+        assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        String id = created.getBody().getId();
+        assertThat(created.getBody().getSourceName()).isEqualTo("lecture.pdf");
+
+        // List as A returns the card
+        ResponseEntity<Flashcard[]> list = rest.exchange(
+                "/api/v1/flashcards", HttpMethod.GET,
+                new HttpEntity<>(authFor(userA)), Flashcard[].class);
+        assertThat(list.getBody()).hasSize(1);
+
+        // User B cannot see user A's card
+        ResponseEntity<String> asB = rest.exchange(
+                "/api/v1/flashcards/" + id, HttpMethod.GET,
+                new HttpEntity<>(authFor(userB)), String.class);
+        assertThat(asB.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+
+        // Update as A
+        String updateBody = "{\"question\":\"Q2\",\"answer\":\"A2\",\"source_ref\":\"upload-2\"}";
+        ResponseEntity<Flashcard> updated = rest.exchange(
+                "/api/v1/flashcards/" + id, HttpMethod.PUT,
+                new HttpEntity<>(updateBody, authFor(userA)), Flashcard.class);
+        assertThat(updated.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(updated.getBody().getQuestion()).isEqualTo("Q2");
+
+        // Batch-get as A
+        ResponseEntity<Flashcard[]> batch = rest.exchange(
+                "/api/v1/flashcards/batch-get", HttpMethod.POST,
+                new HttpEntity<>("{\"ids\":[\"" + id + "\"]}", authFor(userA)), Flashcard[].class);
+        assertThat(batch.getBody()).hasSize(1);
+
+        // Delete as A
+        ResponseEntity<Void> deleted = rest.exchange(
+                "/api/v1/flashcards/" + id, HttpMethod.DELETE,
+                new HttpEntity<>(authFor(userA)), Void.class);
+        assertThat(deleted.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        // Now gone
+        ResponseEntity<String> afterDelete = rest.exchange(
+                "/api/v1/flashcards/" + id, HttpMethod.GET,
+                new HttpEntity<>(authFor(userA)), String.class);
+        assertThat(afterDelete.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+}

--- a/services/flashcard-service/src/test/java/com/devops/springservice/flashcard/FlashcardControllerTest.java
+++ b/services/flashcard-service/src/test/java/com/devops/springservice/flashcard/FlashcardControllerTest.java
@@ -1,0 +1,161 @@
+package com.devops.springservice.flashcard;
+
+import com.devops.springservice.model.Flashcard;
+import com.devops.springservice.model.FlashcardCreateRequest;
+import com.devops.springservice.model.FlashcardUpdateRequest;
+import com.devops.springservice.security.JwtAuthFilter;
+import com.devops.springservice.security.SecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-layer (slice) tests for {@link FlashcardController}: HTTP mapping,
+ * request validation, authentication enforcement, and error translation.
+ * The service layer is mocked.
+ */
+@WebMvcTest(FlashcardController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+@TestPropertySource(properties = "jwt.secret=test-secret-that-is-at-least-32-characters!!")
+class FlashcardControllerTest {
+
+    private static final UUID USER_ID = UUID.randomUUID();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private FlashcardService service;
+
+    private RequestPostProcessor asUser() {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                USER_ID.toString(), null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        return authentication(auth);
+    }
+
+    private Flashcard sample(String id) {
+        return new Flashcard(id, "What is a hypervisor?", "Runs VMs.", "upload-1", OffsetDateTime.now())
+                .sourceName("lecture.pdf");
+    }
+
+    @Test
+    void listRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/flashcards"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void listReturnsUsersCards() throws Exception {
+        when(service.listForUser(USER_ID)).thenReturn(List.of(sample(UUID.randomUUID().toString())));
+
+        mockMvc.perform(get("/api/v1/flashcards").with(asUser()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].question").value("What is a hypervisor?"))
+                .andExpect(jsonPath("$[0].source_name").value("lecture.pdf"));
+    }
+
+    @Test
+    void createReturns201WithBody() throws Exception {
+        String id = UUID.randomUUID().toString();
+        when(service.create(eq(USER_ID), any())).thenReturn(sample(id));
+
+        FlashcardCreateRequest req = new FlashcardCreateRequest("Q", "A", "upload-1").sourceName("lecture.pdf");
+
+        mockMvc.perform(post("/api/v1/flashcards").with(asUser()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(id));
+    }
+
+    @Test
+    void createRejectsInvalidBodyWith400() throws Exception {
+        mockMvc.perform(post("/api/v1/flashcards").with(asUser()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+    }
+
+    @Test
+    void getByIdReturns404WhenMissing() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(service.getForUser(eq(USER_ID), eq(id))).thenThrow(new FlashcardNotFoundException(id));
+
+        mockMvc.perform(get("/api/v1/flashcards/{id}", id).with(asUser()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("FLASHCARD_NOT_FOUND"));
+    }
+
+    @Test
+    void getByIdReturns400ForMalformedId() throws Exception {
+        mockMvc.perform(get("/api/v1/flashcards/not-a-uuid").with(asUser()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void updateReturnsUpdatedCard() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(service.update(eq(USER_ID), eq(id), any())).thenReturn(sample(id.toString()));
+
+        FlashcardUpdateRequest req = new FlashcardUpdateRequest("New Q", "New A", "upload-2");
+
+        mockMvc.perform(put("/api/v1/flashcards/{id}", id).with(asUser()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id.toString()));
+    }
+
+    @Test
+    void deleteReturns204() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/v1/flashcards/{id}", id).with(asUser()).with(csrf()))
+                .andExpect(status().isNoContent());
+
+        verify(service).delete(USER_ID, id);
+    }
+
+    @Test
+    void batchGetReturnsCards() throws Exception {
+        String id = UUID.randomUUID().toString();
+        when(service.getForUser(eq(USER_ID), any(List.class))).thenReturn(List.of(sample(id)));
+
+        mockMvc.perform(post("/api/v1/flashcards/batch-get").with(asUser()).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"ids\":[\"" + id + "\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(id));
+    }
+}

--- a/services/flashcard-service/src/test/java/com/devops/springservice/flashcard/FlashcardRepositoryIntegrationTest.java
+++ b/services/flashcard-service/src/test/java/com/devops/springservice/flashcard/FlashcardRepositoryIntegrationTest.java
@@ -1,0 +1,94 @@
+package com.devops.springservice.flashcard;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the persistence layer against a real PostgreSQL
+ * (Testcontainers). Liquibase migrations run on startup and Hibernate validates
+ * the entity mapping against the migrated schema, so these exercise the real
+ * SQL, constraints, and derived queries — not mocks.
+ */
+@SpringBootTest
+@Testcontainers
+class FlashcardRepositoryIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    private static final UUID USER_A = UUID.randomUUID();
+    private static final UUID USER_B = UUID.randomUUID();
+
+    @Autowired
+    private FlashcardRepository repository;
+
+    @BeforeEach
+    void reset() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void persistsGeneratedIdAndTimestampScopedByUser() {
+        FlashcardEntity a1 = repository.save(new FlashcardEntity(USER_A, "Qa1", "A", "u1", "a.pdf"));
+        repository.save(new FlashcardEntity(USER_A, "Qa2", "A", "u1", "a.pdf"));
+        repository.save(new FlashcardEntity(USER_B, "Qb1", "A", "u2", "b.pdf"));
+
+        assertThat(a1.getId()).isNotNull();
+        assertThat(a1.getLastUpdated()).isNotNull();
+        assertThat(repository.findByUserIdOrderByLastUpdatedDesc(USER_A)).hasSize(2);
+        assertThat(repository.findByUserIdOrderByLastUpdatedDesc(USER_B)).hasSize(1);
+    }
+
+    @Test
+    void findByIdAndUserIdEnforcesOwnership() {
+        FlashcardEntity a = repository.save(new FlashcardEntity(USER_A, "Q", "A", "u", "a.pdf"));
+
+        assertThat(repository.findByIdAndUserId(a.getId(), USER_A)).isPresent();
+        assertThat(repository.findByIdAndUserId(a.getId(), USER_B)).isEmpty();
+    }
+
+    @Test
+    void findByIdInAndUserIdReturnsOnlyOwnedMatches() {
+        FlashcardEntity a = repository.save(new FlashcardEntity(USER_A, "Q", "A", "u", "a.pdf"));
+        FlashcardEntity b = repository.save(new FlashcardEntity(USER_B, "Q", "A", "u", "b.pdf"));
+
+        List<FlashcardEntity> found = repository.findByIdInAndUserId(List.of(a.getId(), b.getId()), USER_A);
+
+        assertThat(found).extracting(FlashcardEntity::getId).containsExactly(a.getId());
+    }
+
+    // Derived delete queries require an active transaction, which the
+    // FlashcardService provides in production via @Transactional.
+    @Test
+    @Transactional
+    void deleteByIdAndUserIdReturnsAffectedCount() {
+        FlashcardEntity a = repository.save(new FlashcardEntity(USER_A, "Q", "A", "u", "a.pdf"));
+
+        assertThat(repository.deleteByIdAndUserId(a.getId(), USER_B)).isZero();
+        assertThat(repository.deleteByIdAndUserId(a.getId(), USER_A)).isEqualTo(1L);
+        assertThat(repository.findById(a.getId())).isEmpty();
+    }
+
+    @Test
+    void persistsLongTextAndNullableSourceName() {
+        String longAnswer = "x".repeat(5000);
+        FlashcardEntity saved = repository.save(new FlashcardEntity(USER_A, "Q", longAnswer, "u", null));
+
+        FlashcardEntity reloaded = repository.findById(saved.getId()).orElseThrow();
+        assertThat(reloaded.getAnswer()).hasSize(5000);
+        assertThat(reloaded.getSourceName()).isNull();
+    }
+}

--- a/services/genai-service/tests/test_acceptance.py
+++ b/services/genai-service/tests/test_acceptance.py
@@ -1,0 +1,86 @@
+"""Integration/acceptance tests for the GenAI service HTTP API.
+
+These drive the FastAPI app through a TestClient. External dependencies
+(the upload service, the vector store, and the LLM pipeline) are mocked so the
+tests exercise the API contract, routing, streaming, and error handling — not
+the model itself.
+"""
+
+import datetime
+import json
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from openapi_server.models.flashcard import Flashcard
+
+
+def _card(i: int) -> Flashcard:
+    return Flashcard(
+        id=f"c{i}",
+        question=f"Q{i}",
+        answer=f"A{i}",
+        source_ref="upload-1",
+        last_updated=datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+
+
+def test_health_returns_ok(client: TestClient):
+    response = client.get("/api/v1/genai/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_generate_flashcards_streams_ndjson(client: TestClient):
+    with patch("openapi_server.impl.controller.UploadServiceClientAPIs") as mock_client, \
+            patch("openapi_server.impl.controller.upsert_markdown_to_weaviate") as mock_upsert, \
+            patch("openapi_server.impl.controller.generate_flashcards_stream") as mock_stream:
+        mock_client.return_value.documents_get_documents_upload_id_get.return_value = "# lecture"
+        mock_stream.return_value = iter([_card(1), _card(2)])
+
+        response = client.post(
+            "/api/v1/genai/generate-flashcards", params={"upload_id": "upload-1"}
+        )
+
+        assert response.status_code == 200
+        lines = [line for line in response.text.splitlines() if line.strip()]
+        assert len(lines) == 2
+        assert json.loads(lines[0])["question"] == "Q1"
+        assert json.loads(lines[1])["answer"] == "A2"
+        mock_upsert.assert_called_once()
+        mock_stream.assert_called_once_with("upload-1")
+
+
+def test_explain_returns_explanation(client: TestClient):
+    flashcard = {
+        "id": "c1",
+        "question": "What is a hypervisor?",
+        "answer": "Runs VMs.",
+        "source_ref": "upload-1",
+        "last_updated": "2026-01-01T00:00:00Z",
+    }
+    with patch(
+        "openapi_server.impl.controller.generate_explanation",
+        return_value="Because it virtualizes hardware.",
+    ):
+        response = client.post("/api/v1/genai/explain", json=flashcard)
+
+    assert response.status_code == 200
+    assert response.json()["explanation"] == "Because it virtualizes hardware."
+
+
+def test_explain_propagates_server_error(client: TestClient):
+    flashcard = {
+        "id": "c1",
+        "question": "Q",
+        "answer": "A",
+        "source_ref": "upload-1",
+        "last_updated": "2026-01-01T00:00:00Z",
+    }
+    with patch(
+        "openapi_server.impl.controller.generate_explanation",
+        side_effect=RuntimeError("llm down"),
+    ):
+        response = client.post("/api/v1/genai/explain", json=flashcard)
+
+    assert response.status_code == 500

--- a/services/study-service/pom.xml
+++ b/services/study-service/pom.xml
@@ -23,6 +23,20 @@
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Newer Testcontainers/docker-java: the version managed by Spring Boot
+                 3.3 negotiates Docker API 1.32, which modern engines (OrbStack) reject. -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.20.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -108,6 +122,27 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Lets TestRestTemplate issue PATCH requests (the JDK client cannot). -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -115,6 +150,37 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Pin Docker API version for Testcontainers; the default 1.32
+                         is rejected by engines with min API 1.40 (e.g. OrbStack). -->
+                    <systemPropertyVariables>
+                        <api.version>1.41</api.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.openapitools</groupId>

--- a/services/study-service/src/main/java/com/devops/studyservice/service/StudyService.java
+++ b/services/study-service/src/main/java/com/devops/studyservice/service/StudyService.java
@@ -8,6 +8,7 @@ import com.devops.studyservice.model.StudyStatus;
 import com.devops.studyservice.repository.StudyRecordRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -106,6 +107,7 @@ public class StudyService {
         return studyRecordRepository.save(record);
     }
 
+    @Transactional
     public void deleteRecord(DeckEntity deck, String flashcardId) {
         StudyRecordEntity record = findRecord(deck, flashcardId);
         studyRecordRepository.delete(record);

--- a/services/study-service/src/test/java/com/devops/studyservice/acceptance/StudyAcceptanceTest.java
+++ b/services/study-service/src/test/java/com/devops/studyservice/acceptance/StudyAcceptanceTest.java
@@ -1,0 +1,119 @@
+package com.devops.studyservice.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Acceptance tests driving the study service over HTTP against a real
+ * PostgreSQL, authenticating with a signed JWT cookie. Exercises the deck
+ * lifecycle, deck-flashcard membership, study-status updates, and per-user
+ * isolation end-to-end.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class StudyAcceptanceTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    private final String userA = UUID.randomUUID().toString();
+    private final String userB = UUID.randomUUID().toString();
+
+    private HttpHeaders authFor(String userId) {
+        String token = Jwts.builder()
+                .subject(userId)
+                .signWith(Keys.hmacShaKeyFor(jwtSecret.getBytes()))
+                .compact();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.COOKIE, "access_token=" + token);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+
+    private String createDeck(String userId, String name) throws Exception {
+        ResponseEntity<String> response = rest.exchange("/api/v1/decks", HttpMethod.POST,
+                new HttpEntity<>("{\"name\":\"" + name + "\",\"tags\":[\"cs\"]}", authFor(userId)), String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        return objectMapper.readTree(response.getBody()).get("id").asText();
+    }
+
+    @Test
+    void unauthenticatedIsRejected() {
+        ResponseEntity<String> response = rest.getForEntity("/api/v1/decks", String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void deckLifecycleWithUserIsolation() throws Exception {
+        String deckId = createDeck(userA, "Algorithms");
+
+        // Owner sees the deck in their list
+        ResponseEntity<String> list = rest.exchange("/api/v1/decks", HttpMethod.GET,
+                new HttpEntity<>(authFor(userA)), String.class);
+        assertThat(list.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(list.getBody()).contains(deckId);
+
+        // Owner can fetch it; another user cannot
+        assertThat(rest.exchange("/api/v1/decks/" + deckId, HttpMethod.GET,
+                new HttpEntity<>(authFor(userA)), String.class).getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(rest.exchange("/api/v1/decks/" + deckId, HttpMethod.GET,
+                new HttpEntity<>(authFor(userB)), String.class).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void flashcardMembershipAndStudyStatusFlow() throws Exception {
+        String deckId = createDeck(userA, "Databases");
+        String flashcardId = UUID.randomUUID().toString();
+
+        // Add a flashcard to the deck
+        ResponseEntity<String> added = rest.exchange("/api/v1/decks/" + deckId + "/flashcards", HttpMethod.POST,
+                new HttpEntity<>("{\"flashcard_id\":\"" + flashcardId + "\"}", authFor(userA)), String.class);
+        assertThat(added.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        // It shows up in the deck's flashcard id list
+        ResponseEntity<String> ids = rest.exchange("/api/v1/decks/" + deckId + "/flashcards", HttpMethod.GET,
+                new HttpEntity<>(authFor(userA)), String.class);
+        assertThat(ids.getBody()).contains(flashcardId);
+
+        // Report a study result (spaced repetition), then remove it
+        ResponseEntity<String> studied = rest.exchange(
+                "/api/v1/decks/" + deckId + "/flashcards/" + flashcardId + "/study-status", HttpMethod.PATCH,
+                new HttpEntity<>("{\"study_status\":\"good\"}", authFor(userA)), String.class);
+        assertThat(studied.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        ResponseEntity<Void> deleted = rest.exchange(
+                "/api/v1/decks/" + deckId + "/flashcards/" + flashcardId + "/study-status", HttpMethod.DELETE,
+                new HttpEntity<>(authFor(userA)), Void.class);
+        assertThat(deleted.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+}

--- a/services/study-service/src/test/java/com/devops/studyservice/integration/StudyPersistenceIntegrationTest.java
+++ b/services/study-service/src/test/java/com/devops/studyservice/integration/StudyPersistenceIntegrationTest.java
@@ -1,0 +1,112 @@
+package com.devops.studyservice.integration;
+
+import com.devops.studyservice.entity.DeckEntity;
+import com.devops.studyservice.entity.StudyRecordEntity;
+import com.devops.studyservice.repository.DeckRepository;
+import com.devops.studyservice.repository.StudyRecordRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the study persistence layer against a real PostgreSQL
+ * (Testcontainers): deck ownership queries, deck-tag element collection, and the
+ * spaced-repetition study-record queries (due lookups, counts, deletes).
+ */
+@SpringBootTest
+@Testcontainers
+class StudyPersistenceIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    private static final String USER_A = "user-a";
+    private static final String USER_B = "user-b";
+
+    @Autowired
+    private DeckRepository deckRepository;
+
+    @Autowired
+    private StudyRecordRepository studyRecordRepository;
+
+    private DeckEntity newDeck(String userId, String name) {
+        DeckEntity deck = new DeckEntity();
+        deck.setUserId(userId);
+        deck.setName(name);
+        deck.setTags(List.of("cs", "exam"));
+        return deck;
+    }
+
+    private StudyRecordEntity newRecord(UUID deckId, String flashcardId, Instant dueAt) {
+        StudyRecordEntity record = new StudyRecordEntity();
+        record.setDeckId(deckId);
+        record.setFlashcardId(flashcardId);
+        record.setDueAt(dueAt);
+        record.setIntervalDays(1);
+        record.setEaseFactor(2.5);
+        return record;
+    }
+
+    // @Transactional keeps the session open so the lazy @ElementCollection tags load.
+    @Test
+    @Transactional
+    void decksAreScopedToOwnerAndPersistTags() {
+        deckRepository.save(newDeck(USER_A, "Algorithms"));
+        DeckEntity owned = deckRepository.save(newDeck(USER_A, "Databases"));
+        deckRepository.save(newDeck(USER_B, "Networks"));
+
+        assertThat(deckRepository.findByUserIdOrderByCreatedAtAsc(USER_A)).hasSize(2);
+        assertThat(deckRepository.findByIdAndUserId(owned.getId(), USER_A)).isPresent();
+        assertThat(deckRepository.findByIdAndUserId(owned.getId(), USER_B)).isEmpty();
+        assertThat(deckRepository.findById(owned.getId()).orElseThrow().getTags())
+                .containsExactlyInAnyOrder("cs", "exam");
+    }
+
+    @Test
+    void studyRecordDueQueriesAndCounts() {
+        DeckEntity deck = deckRepository.save(newDeck(USER_A, "Deck"));
+        UUID deckId = deck.getId();
+        Instant now = Instant.now();
+
+        studyRecordRepository.save(newRecord(deckId, "c1", now.minus(1, ChronoUnit.DAYS))); // due
+        studyRecordRepository.save(newRecord(deckId, "c2", now.minus(2, ChronoUnit.HOURS))); // due
+        studyRecordRepository.save(newRecord(deckId, "c3", now.plus(3, ChronoUnit.DAYS)));   // not due
+
+        assertThat(studyRecordRepository.countByDeckId(deckId)).isEqualTo(3L);
+        assertThat(studyRecordRepository.countByDeckIdAndDueAtLessThanEqual(deckId, now)).isEqualTo(2L);
+        assertThat(studyRecordRepository.existsByDeckIdAndFlashcardId(deckId, "c1")).isTrue();
+        assertThat(studyRecordRepository.existsByDeckIdAndFlashcardId(deckId, "nope")).isFalse();
+
+        List<StudyRecordEntity> due =
+                studyRecordRepository.findTop5ByDeckIdAndDueAtLessThanEqualOrderByDueAtAsc(deckId, now);
+        assertThat(due).extracting(StudyRecordEntity::getFlashcardId).containsExactly("c1", "c2");
+
+        List<String> allByCard = studyRecordRepository.findByDeckIdOrderByFlashcardIdAsc(deckId)
+                .stream().map(StudyRecordEntity::getFlashcardId).toList();
+        assertThat(allByCard).containsExactly("c1", "c2", "c3");
+    }
+
+    @Test
+    @Transactional
+    void deleteRecordByDeckAndFlashcard() {
+        DeckEntity deck = deckRepository.save(newDeck(USER_A, "Deck"));
+        studyRecordRepository.save(newRecord(deck.getId(), "c1", Instant.now()));
+
+        assertThat(studyRecordRepository.findByDeckIdAndFlashcardId(deck.getId(), "c1")).isPresent();
+        studyRecordRepository.deleteByDeckIdAndFlashcardId(deck.getId(), "c1");
+        assertThat(studyRecordRepository.findByDeckIdAndFlashcardId(deck.getId(), "c1")).isEmpty();
+    }
+}

--- a/services/upload-service/src/openapi_server/storage.py
+++ b/services/upload-service/src/openapi_server/storage.py
@@ -10,7 +10,7 @@ from markitdown import MarkItDown
 from fastapi import HTTPException, status
 
 
-ALLOWED_EXTENSIONS = {".pdf", ".txt", ".md", ".docx", "pptx"}
+ALLOWED_EXTENSIONS = {".pdf", ".txt", ".md", ".docx", ".pptx"}
 POSTGRES_USER = os.getenv("POSTGRES_USER")
 POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD")
 POSTGRES_DB = os.getenv("POSTGRES_DB", "uploaddocumentdb")

--- a/services/upload-service/tests/test_acceptance.py
+++ b/services/upload-service/tests/test_acceptance.py
@@ -1,0 +1,61 @@
+"""Integration/acceptance tests for the Upload service HTTP API.
+
+Drives the FastAPI app through a TestClient across the full request path
+(multipart parsing, extension validation, markdown conversion, response models).
+The database persistence layer is mocked; conversion is stubbed so the tests do
+not depend on MarkItDown internals.
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+def test_health_returns_ok(client: TestClient):
+    response = client.get("/api/v1/documents/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_upload_txt_returns_upload_id(client: TestClient):
+    with patch("openapi_server.impl.controller.convert_to_markdown", return_value="# notes"), \
+            patch("openapi_server.impl.controller.store_markdown", return_value="upload-123"):
+        response = client.post(
+            "/api/v1/documents/upload",
+            files={"file": ("notes.txt", b"hello world", "text/plain")},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"upload_id": "upload-123"}
+
+
+def test_upload_empty_file_is_rejected(client: TestClient):
+    response = client.post(
+        "/api/v1/documents/upload",
+        files={"file": ("empty.txt", b"", "text/plain")},
+    )
+    assert response.status_code == 400
+
+
+def test_upload_unsupported_extension_is_rejected(client: TestClient):
+    response = client.post(
+        "/api/v1/documents/upload",
+        files={"file": ("malware.exe", b"data", "application/octet-stream")},
+    )
+    assert response.status_code == 415
+
+
+def test_get_document_returns_content(client: TestClient):
+    with patch("openapi_server.impl.controller.get_document", return_value="# stored"):
+        response = client.get("/api/v1/documents/upload-123")
+
+    assert response.status_code == 200
+    assert response.text == "# stored"
+    assert response.headers["content-type"].startswith("text/markdown")
+
+
+def test_get_missing_document_returns_404(client: TestClient):
+    with patch("openapi_server.impl.controller.get_document", return_value=None):
+        response = client.get("/api/v1/documents/does-not-exist")
+
+    assert response.status_code == 404

--- a/services/upload-service/tests/test_validate_extension.py
+++ b/services/upload-service/tests/test_validate_extension.py
@@ -11,6 +11,7 @@ from openapi_server.storage import validate_extension
     ("slides.pdf", ".pdf"),
     ("report.DOCX", ".docx"),
     ("readme.md", ".md"),
+    ("presentation.pptx", ".pptx"),
 ])
 def test_allowed_extensions_are_returned_lowercased(filename, expected):
     assert validate_extension(filename) == expected

--- a/services/upload-service/tests/test_validate_extension.py
+++ b/services/upload-service/tests/test_validate_extension.py
@@ -1,0 +1,27 @@
+"""Unit tests for the file-extension validation logic."""
+
+import pytest
+from fastapi import HTTPException
+
+from openapi_server.storage import validate_extension
+
+
+@pytest.mark.parametrize("filename,expected", [
+    ("notes.txt", ".txt"),
+    ("slides.pdf", ".pdf"),
+    ("report.DOCX", ".docx"),
+    ("readme.md", ".md"),
+])
+def test_allowed_extensions_are_returned_lowercased(filename, expected):
+    assert validate_extension(filename) == expected
+
+
+def test_missing_filename_returns_empty():
+    assert validate_extension(None) == ""
+    assert validate_extension("") == ""
+
+
+def test_unsupported_extension_raises_415():
+    with pytest.raises(HTTPException) as exc:
+        validate_extension("malware.exe")
+    assert exc.value.status_code == 415

--- a/web-client/src/pages/UploadPage.tsx
+++ b/web-client/src/pages/UploadPage.tsx
@@ -131,7 +131,7 @@ export function UploadPage() {
             <input
               ref={fileInputRef}
               type="file"
-              accept=".pdf,.ppt,.pptx,.docx"
+              accept=".pdf,.pptx,.docx,"
               className="hidden"
               onChange={handleFileChange}
             />


### PR DESCRIPTION
…rvices

Adds the missing test-pyramid layers (real-DB integration and end-to-end acceptance) on top of the existing unit tests for every service, wires up coverage reporting, and fixes a production bug found by the new tests.

Java services (Testcontainers Postgres for integration/acceptance):
- flashcard-service: web-slice (controller), repository integration, and full CRUD acceptance (HTTP + JWT + user isolation); JaCoCo; add to CI test matrix
- auth-service: repository integration + register/login/refresh/logout acceptance
- api-gateway: WireMock-backed routing/auth acceptance (reject, forward, header injection, transparent token refresh)
- study-service: repository integration + deck/study acceptance
- Testcontainers BOM 1.20.4 + pin Docker api.version=1.41 (older client negotiates 1.32, rejected by engines with min API 1.40); JaCoCo everywhere

study-service fix: make StudyService.deleteRecord @Transactional. The derived delete requires a transaction; without it the delete endpoint returned 500. Caught by the new acceptance test.

Python services:
- genai-service: FastAPI acceptance tests (health, NDJSON streaming, explain)
- upload-service: API acceptance + validate_extension unit tests
- pytest-cov wired into the Python CI workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for deleting study records by ensuring the operation completes atomically.
  - Updated upload file extension handling and the upload page so PowerPoint uploads use the correct `.pptx` extension.

- **Tests**
  - Expanded end-to-end and integration testing across authentication, API gateway routing, flashcards, study workflows, document uploads, and GenAI responses.
  - Added/extended persistence and repository tests (including user isolation, session handling, deck tags, and scheduling), plus code coverage reporting in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->