### PR TITLE
Fix: use qwen3 as local model

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ contracts (the single source of truth) live in [`api/`](api/).
 
 UML-style diagrams are in [`documents/diagrams/`](documents/diagrams/):
 
-- **System Structure** - [documents/system_structure.md](documents/diagrams/Subsystem%20Decomposition.md)
+- **System Structure** - [documents/system_structure.md](documents/system_structure.md)
 - **Subsystem Decomposition** — [documents/diagrams/Subsystem Decomposition.md](documents/diagrams/Subsystem%20Decomposition.md)
 - **Use Case Diagram** — `documents/diagrams/Use Case Diagram.pdf`
 - **Analysis Object Model** — `documents/diagrams/Analysis Object Model.png`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ From the `infra/` directory, then run docker compose to start everything (Postgr
 docker compose up --build
 ```
 
-- Note: In the local setup, Google login is unavailable, and the local fallback LLM model is disabled by default so that a 7 GB model doesn't need to be pulled on app start.
+- Note: In the local setup, Google login is unavailable
 
 To stop all services:
 
@@ -132,27 +132,6 @@ cd infra/helm
 helm install [RELEASE_NAME] . --namespace team-continuous-frustration
 ```
 
-## Features
-
-At the moment the Login/ Signup functionality is available end-to-end. The rest of the Fronted is currently mocked.
-
-### Implemented Endpoints
-
-The following endooints are available through the API Gateway:
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/api/v1/auth/register` | POST | Register a new user |
-| `/api/v1/auth/login` | POST | Login with email and password |
-| `/api/v1/auth/login/google` | POST | Login with Google OAuth |
-| `/api/v1/auth/logout` | POST | Logout |
-| `/api/v1/auth/me` | GET | Get current user profile |
-| `/api/v1/auth/refresh` | POST | Refresh authentication token |
-| `/api/v1/documents/upload` | POST | Upload a document |
-| `/api/v1/documents/{upload_id}` | GET | Get a document |
-| `/api/v1/genai/generate-flashcards` | POST | Generate flashcards from an uploaded document |
-
-
 ### API documentation (Swagger UI)
 
 Every service exposes interactive API docs when running locally:
@@ -173,6 +152,7 @@ contracts (the single source of truth) live in [`api/`](api/).
 
 UML-style diagrams are in [`documents/diagrams/`](documents/diagrams/):
 
+- **System Structure** - [documents/system_structure.md](documents/diagrams/Subsystem%20Decomposition.md)
 - **Subsystem Decomposition** — [documents/diagrams/Subsystem Decomposition.md](documents/diagrams/Subsystem%20Decomposition.md)
 - **Use Case Diagram** — `documents/diagrams/Use Case Diagram.pdf`
 - **Analysis Object Model** — `documents/diagrams/Analysis Object Model.png`

--- a/documents/system_structure.md
+++ b/documents/system_structure.md
@@ -90,3 +90,25 @@ These diagrams capture the user interactions, domain model, and component-level 
 4. Generated flashcards are persisted via `flashcard-service`, and organized into decks via `study-service`.
 5. Study sessions are driven by `study-service`, which tracks per-flashcard study status and schedules reviews (spaced-repetition parameters configurable via `STUDY_EASE_*` env vars).
 6. Users can request AI explanations, produced by `genai-service` and returned through the gateway.
+
+## 8. AI component
+
+The `genai-service` (Python/LangChain) talks to LLMs through an OpenAI-compatible
+`/v1/chat/completions` interface, with two backends:
+
+- **Logos API (default)** — TUM-hosted, using the `openai/gpt-oss-120b` model
+  (`LOGOS_BASE_URL`, `LOGOS_MODEL`, `LOGOS_API_KEY`).
+- **Ollama (local fallback)** — a self-hosted `ollama` container running the
+  `qwen3:0.6b` model (`LLM_BASE_URL`, `LLM_MODEL`). Qwen3 0.6B was chosen because of
+  the memory constraints on the Azure VM and the Kubernetes cluster; it's small
+  enough to run on CPU without the pod/VM getting OOM-killed.
+
+At request time, `llm_factory.py` calls Logos first and only falls back to the
+local Ollama model if the Logos call fails (e.g. missing/invalid `LOGOS_API_KEY`
+or the API being unreachable).
+
+Ollama also serves as the embedding provider for the Weaviate vector database
+(used for RAG over uploaded flashcard documents): both the `genai-service`
+(`vector_store.py`) and Weaviate's `text2vec-ollama` module use the
+`nomic-embed-text` model, served from the same `ollama` container
+(`OLLAMA_API_ENDPOINT`).

--- a/infra/docker-compose.azure.yml
+++ b/infra/docker-compose.azure.yml
@@ -111,7 +111,7 @@ services:
       LOGOS_MODEL: ${LOGOS_MODEL:-openai/gpt-oss-120b}
       LOGOS_API_KEY: ${LOGOS_API_KEY}
       LLM_BASE_URL: ${LLM_BASE_URL:-http://ollama:11434/v1}
-      LLM_MODEL: ${LLM_MODEL:-gemma4:e2b}
+      LLM_MODEL: ${LLM_MODEL:-qwen3:0.6b}
       UPLOAD_SERVICE_BASE_URL: ${UPLOAD_SERVICE_BASE_URL:-http://upload-service:8091}
       WEAVIATE_URL: http://weaviate:8080
       OLLAMA_API_ENDPOINT: http://ollama:11434

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       LOGOS_MODEL: ${LOGOS_MODEL:-openai/gpt-oss-120b}
       LOGOS_API_KEY: ${LOGOS_API_KEY}
       LLM_BASE_URL: ${LLM_BASE_URL:-http://ollama:11434/v1}
-      LLM_MODEL: ${LLM_MODEL:-gemma3n:e2b}
+      LLM_MODEL: ${LLM_MODEL:-qwen3:0.6b}
       UPLOAD_SERVICE_BASE_URL: ${UPLOAD_SERVICE_BASE_URL:-http://upload-service:8091}
       WEAVIATE_URL: http://weaviate:8080
       REDIS_URL: redis://redis:6379/0
@@ -141,7 +141,7 @@ services:
     volumes:
       - ollama_data:/root/.ollama
       - ./init-ollama/ollama.sh:/init-ollama/ollama.sh
-    entrypoint: ["/bin/sh", "/init-ollama/ollama.sh"]
+    entrypoint: ["/bin/sh", "/init-ollama/ollama.sh", "--pull-llm"]
 
   redis:
     image: redis:7-alpine

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -91,7 +91,7 @@ genaiService:
   name: genai-service
   replicaCount: 1
   port: 8090
-  llmModel: "gemma4:e2b"
+  llmModel: "qwen3:0.6b"
   resources:
     requests:
       cpu: 200m
@@ -173,7 +173,6 @@ ollama:
   name: ollama
   image: ollama/ollama:0.30.8
   port: 11434
-  pullLlm: false
   storageSize: 10Gi
   resources:
     requests:

--- a/infra/init-ollama/ollama.sh
+++ b/infra/init-ollama/ollama.sh
@@ -14,7 +14,7 @@ echo "🟢 Done!"
 
 if [ "$*" = "--pull-llm" ]; then
     echo "🔴 Retrieve LLM..."
-    ollama pull gemma4:e2b
+    ollama pull qwen3:0.6b
     echo "🟢 Done!"
 fi
 

--- a/services/genai-service/src/openapi_server/core/llm_factory.py
+++ b/services/genai-service/src/openapi_server/core/llm_factory.py
@@ -13,7 +13,7 @@ API_KEY = os.getenv("LOGOS_API_KEY")
 
 # Ollama profile
 LOCAL_BASE_URL = os.getenv("LLM_BASE_URL", "http://ollama:11434/v1")
-LOCAL_LLM_MODEL_NAME = os.getenv("LLM_MODEL", "gemma3n:e2b")
+LOCAL_LLM_MODEL_NAME = os.getenv("LLM_MODEL", "qwen3:0.6b")
 LOCAL_API_KEY = "ollama"
 
 # Request timeout (seconds). Local models can cold-start slowly on CPU, so this


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated local setup guidance to clarify that Google login is unavailable.
  - Added documentation for system structure, AI model selection, fallback behavior, and embeddings.
  - Removed the implemented-endpoints reference section from the README.

- **Improvements**
  - Updated the default AI model used in deployments and local environments.
  - Improved startup configuration so the selected model is available automatically.
  - Documented and supported fallback processing when the primary AI service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->